### PR TITLE
Use attribute.path.is_ident to filter all attributes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1530,35 +1530,33 @@ fn derive_input_handler(ast: DeriveInput) -> TokenStream {
     let mut trait_meta_map: BTreeMap<Trait, Meta> = BTreeMap::new();
 
     for attr in ast.attrs.iter() {
-        if let Some(attr_meta_name) = attr.path.get_ident() {
-            if attr_meta_name == "educe" {
-                let attr_meta = attr.parse_meta().unwrap();
+        if attr.path.is_ident("educe") {
+            let attr_meta = attr.parse_meta().unwrap();
 
-                match attr_meta {
-                    Meta::List(list) => {
-                        for p in list.nested {
-                            match p {
-                                NestedMeta::Meta(meta) => {
-                                    let meta_name = meta.path().into_token_stream().to_string();
+            match attr_meta {
+                Meta::List(list) => {
+                    for p in list.nested {
+                        match p {
+                            NestedMeta::Meta(meta) => {
+                                let meta_name = meta.path().into_token_stream().to_string();
 
-                                    let t = Trait::from_str(meta_name);
+                                let t = Trait::from_str(meta_name);
 
-                                    if trait_meta_map.contains_key(&t) {
-                                        panic::reuse_a_trait(t);
-                                    }
+                                if trait_meta_map.contains_key(&t) {
+                                    panic::reuse_a_trait(t);
+                                }
 
-                                    trait_meta_map.insert(t, meta);
-                                },
-                                NestedMeta::Lit(_) => {
-                                    panic::educe_format_incorrect();
-                                },
-                            }
+                                trait_meta_map.insert(t, meta);
+                            },
+                            NestedMeta::Lit(_) => {
+                                panic::educe_format_incorrect();
+                            },
                         }
-                    },
-                    _ => {
-                        panic::educe_format_incorrect();
-                    },
-                }
+                    }
+                },
+                _ => {
+                    panic::educe_format_incorrect();
+                },
             }
         }
     }

--- a/src/trait_handlers/clone/models/field_attribute.rs
+++ b/src/trait_handlers/clone/models/field_attribute.rs
@@ -200,11 +200,9 @@ impl FieldAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-            let meta_name = meta.path().into_token_stream().to_string();
-
-            if meta_name.as_str() == "educe" {
                 match meta {
                     Meta::List(list) => {
                         for p in list.nested.iter() {

--- a/src/trait_handlers/clone/models/type_attribute.rs
+++ b/src/trait_handlers/clone/models/type_attribute.rs
@@ -208,37 +208,35 @@ impl TypeAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            if let Some(meta_name) = attribute.path.get_ident() {
-                if meta_name == "educe" {
-                    let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-                    match meta {
-                        Meta::List(list) => {
-                            for p in list.nested.iter() {
-                                match p {
-                                    NestedMeta::Meta(meta) => {
-                                        let meta_name = meta.path().into_token_stream().to_string();
+                match meta {
+                    Meta::List(list) => {
+                        for p in list.nested.iter() {
+                            match p {
+                                NestedMeta::Meta(meta) => {
+                                    let meta_name = meta.path().into_token_stream().to_string();
 
-                                        let t = Trait::from_str(meta_name);
+                                    let t = Trait::from_str(meta_name);
 
-                                        if traits.binary_search(&t).is_err() {
-                                            panic::trait_not_used(t);
+                                    if traits.binary_search(&t).is_err() {
+                                        panic::trait_not_used(t);
+                                    }
+
+                                    if t == Trait::Clone {
+                                        if result.is_some() {
+                                            panic::reuse_a_trait(t);
                                         }
 
-                                        if t == Trait::Clone {
-                                            if result.is_some() {
-                                                panic::reuse_a_trait(t);
-                                            }
-
-                                            result = Some(self.from_clone_meta(meta));
-                                        }
-                                    },
-                                    _ => panic::educe_format_incorrect(),
-                                }
+                                        result = Some(self.from_clone_meta(meta));
+                                    }
+                                },
+                                _ => panic::educe_format_incorrect(),
                             }
-                        },
-                        _ => panic::educe_format_incorrect(),
-                    }
+                        }
+                    },
+                    _ => panic::educe_format_incorrect(),
                 }
             }
         }

--- a/src/trait_handlers/debug/models/field_attribute.rs
+++ b/src/trait_handlers/debug/models/field_attribute.rs
@@ -451,11 +451,9 @@ impl FieldAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-            let meta_name = meta.path().into_token_stream().to_string();
-
-            if meta_name.as_str() == "educe" {
                 match meta {
                     Meta::List(list) => {
                         for p in list.nested.iter() {

--- a/src/trait_handlers/debug/models/type_attribute.rs
+++ b/src/trait_handlers/debug/models/type_attribute.rs
@@ -460,37 +460,35 @@ impl TypeAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            if let Some(meta_name) = attribute.path.get_ident() {
-                if meta_name == "educe" {
-                    let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-                    match meta {
-                        Meta::List(list) => {
-                            for p in list.nested.iter() {
-                                match p {
-                                    NestedMeta::Meta(meta) => {
-                                        let meta_name = meta.path().into_token_stream().to_string();
+                match meta {
+                    Meta::List(list) => {
+                        for p in list.nested.iter() {
+                            match p {
+                                NestedMeta::Meta(meta) => {
+                                    let meta_name = meta.path().into_token_stream().to_string();
 
-                                        let t = Trait::from_str(meta_name);
+                                    let t = Trait::from_str(meta_name);
 
-                                        if traits.binary_search(&t).is_err() {
-                                            panic::trait_not_used(t);
+                                    if traits.binary_search(&t).is_err() {
+                                        panic::trait_not_used(t);
+                                    }
+
+                                    if t == Trait::Debug {
+                                        if result.is_some() {
+                                            panic::reuse_a_trait(t);
                                         }
 
-                                        if t == Trait::Debug {
-                                            if result.is_some() {
-                                                panic::reuse_a_trait(t);
-                                            }
-
-                                            result = Some(self.from_debug_meta(meta));
-                                        }
-                                    },
-                                    _ => panic::educe_format_incorrect(),
-                                }
+                                        result = Some(self.from_debug_meta(meta));
+                                    }
+                                },
+                                _ => panic::educe_format_incorrect(),
                             }
-                        },
-                        _ => panic::educe_format_incorrect(),
-                    }
+                        }
+                    },
+                    _ => panic::educe_format_incorrect(),
                 }
             }
         }

--- a/src/trait_handlers/default/models/field_attribute.rs
+++ b/src/trait_handlers/default/models/field_attribute.rs
@@ -179,11 +179,9 @@ impl FieldAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-            let meta_name = meta.path().into_token_stream().to_string();
-
-            if meta_name.as_str() == "educe" {
                 match meta {
                     Meta::List(list) => {
                         for p in list.nested.iter() {

--- a/src/trait_handlers/default/models/type_attribute.rs
+++ b/src/trait_handlers/default/models/type_attribute.rs
@@ -316,37 +316,35 @@ impl TypeAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            if let Some(meta_name) = attribute.path.get_ident() {
-                if meta_name == "educe" {
-                    let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-                    match meta {
-                        Meta::List(list) => {
-                            for p in list.nested.iter() {
-                                match p {
-                                    NestedMeta::Meta(meta) => {
-                                        let meta_name = meta.path().into_token_stream().to_string();
+                match meta {
+                    Meta::List(list) => {
+                        for p in list.nested.iter() {
+                            match p {
+                                NestedMeta::Meta(meta) => {
+                                    let meta_name = meta.path().into_token_stream().to_string();
 
-                                        let t = Trait::from_str(meta_name);
+                                    let t = Trait::from_str(meta_name);
 
-                                        if traits.binary_search(&t).is_err() {
-                                            panic::trait_not_used(t);
+                                    if traits.binary_search(&t).is_err() {
+                                        panic::trait_not_used(t);
+                                    }
+
+                                    if t == Trait::Default {
+                                        if result.is_some() {
+                                            panic::reuse_a_trait(t);
                                         }
 
-                                        if t == Trait::Default {
-                                            if result.is_some() {
-                                                panic::reuse_a_trait(t);
-                                            }
-
-                                            result = Some(self.from_default_meta(meta));
-                                        }
-                                    },
-                                    _ => panic::educe_format_incorrect(),
-                                }
+                                        result = Some(self.from_default_meta(meta));
+                                    }
+                                },
+                                _ => panic::educe_format_incorrect(),
                             }
-                        },
-                        _ => panic::educe_format_incorrect(),
-                    }
+                        }
+                    },
+                    _ => panic::educe_format_incorrect(),
                 }
             }
         }

--- a/src/trait_handlers/deref/models/field_attribute.rs
+++ b/src/trait_handlers/deref/models/field_attribute.rs
@@ -54,11 +54,9 @@ impl FieldAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-            let meta_name = meta.path().into_token_stream().to_string();
-
-            if meta_name.as_str() == "educe" {
                 match meta {
                     Meta::List(list) => {
                         for p in list.nested.iter() {

--- a/src/trait_handlers/deref/models/type_attribute.rs
+++ b/src/trait_handlers/deref/models/type_attribute.rs
@@ -54,37 +54,35 @@ impl TypeAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            if let Some(meta_name) = attribute.path.get_ident() {
-                if meta_name == "educe" {
-                    let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-                    match meta {
-                        Meta::List(list) => {
-                            for p in list.nested.iter() {
-                                match p {
-                                    NestedMeta::Meta(meta) => {
-                                        let meta_name = meta.path().into_token_stream().to_string();
+                match meta {
+                    Meta::List(list) => {
+                        for p in list.nested.iter() {
+                            match p {
+                                NestedMeta::Meta(meta) => {
+                                    let meta_name = meta.path().into_token_stream().to_string();
 
-                                        let t = Trait::from_str(meta_name);
+                                    let t = Trait::from_str(meta_name);
 
-                                        if traits.binary_search(&t).is_err() {
-                                            panic::trait_not_used(t);
+                                    if traits.binary_search(&t).is_err() {
+                                        panic::trait_not_used(t);
+                                    }
+
+                                    if t == Trait::Deref {
+                                        if result.is_some() {
+                                            panic::reuse_a_trait(t);
                                         }
 
-                                        if t == Trait::Deref {
-                                            if result.is_some() {
-                                                panic::reuse_a_trait(t);
-                                            }
-
-                                            result = Some(self.from_deref_meta(meta));
-                                        }
-                                    },
-                                    _ => panic::educe_format_incorrect(),
-                                }
+                                        result = Some(self.from_deref_meta(meta));
+                                    }
+                                },
+                                _ => panic::educe_format_incorrect(),
                             }
-                        },
-                        _ => panic::educe_format_incorrect(),
-                    }
+                        }
+                    },
+                    _ => panic::educe_format_incorrect(),
                 }
             }
         }

--- a/src/trait_handlers/deref_mut/models/field_attribute.rs
+++ b/src/trait_handlers/deref_mut/models/field_attribute.rs
@@ -57,11 +57,9 @@ impl FieldAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-            let meta_name = meta.path().into_token_stream().to_string();
-
-            if meta_name.as_str() == "educe" {
                 match meta {
                     Meta::List(list) => {
                         for p in list.nested.iter() {

--- a/src/trait_handlers/deref_mut/models/type_attribute.rs
+++ b/src/trait_handlers/deref_mut/models/type_attribute.rs
@@ -55,37 +55,35 @@ impl TypeAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            if let Some(meta_name) = attribute.path.get_ident() {
-                if meta_name == "educe" {
-                    let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-                    match meta {
-                        Meta::List(list) => {
-                            for p in list.nested.iter() {
-                                match p {
-                                    NestedMeta::Meta(meta) => {
-                                        let meta_name = meta.path().into_token_stream().to_string();
+                match meta {
+                    Meta::List(list) => {
+                        for p in list.nested.iter() {
+                            match p {
+                                NestedMeta::Meta(meta) => {
+                                    let meta_name = meta.path().into_token_stream().to_string();
 
-                                        let t = Trait::from_str(meta_name);
+                                    let t = Trait::from_str(meta_name);
 
-                                        if traits.binary_search(&t).is_err() {
-                                            panic::trait_not_used(t);
+                                    if traits.binary_search(&t).is_err() {
+                                        panic::trait_not_used(t);
+                                    }
+
+                                    if t == Trait::DerefMut {
+                                        if result.is_some() {
+                                            panic::reuse_a_trait(t);
                                         }
 
-                                        if t == Trait::DerefMut {
-                                            if result.is_some() {
-                                                panic::reuse_a_trait(t);
-                                            }
-
-                                            result = Some(self.from_deref_mut_meta(meta));
-                                        }
-                                    },
-                                    _ => panic::educe_format_incorrect(),
-                                }
+                                        result = Some(self.from_deref_mut_meta(meta));
+                                    }
+                                },
+                                _ => panic::educe_format_incorrect(),
                             }
-                        },
-                        _ => panic::educe_format_incorrect(),
-                    }
+                        }
+                    },
+                    _ => panic::educe_format_incorrect(),
                 }
             }
         }

--- a/src/trait_handlers/hash/models/field_attribute.rs
+++ b/src/trait_handlers/hash/models/field_attribute.rs
@@ -239,11 +239,9 @@ impl FieldAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-            let meta_name = meta.path().into_token_stream().to_string();
-
-            if meta_name.as_str() == "educe" {
                 match meta {
                     Meta::List(list) => {
                         for p in list.nested.iter() {

--- a/src/trait_handlers/hash/models/type_attribute.rs
+++ b/src/trait_handlers/hash/models/type_attribute.rs
@@ -194,37 +194,35 @@ impl TypeAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            if let Some(meta_name) = attribute.path.get_ident() {
-                if meta_name == "educe" {
-                    let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-                    match meta {
-                        Meta::List(list) => {
-                            for p in list.nested.iter() {
-                                match p {
-                                    NestedMeta::Meta(meta) => {
-                                        let meta_name = meta.path().into_token_stream().to_string();
+                match meta {
+                    Meta::List(list) => {
+                        for p in list.nested.iter() {
+                            match p {
+                                NestedMeta::Meta(meta) => {
+                                    let meta_name = meta.path().into_token_stream().to_string();
 
-                                        let t = Trait::from_str(meta_name);
+                                    let t = Trait::from_str(meta_name);
 
-                                        if traits.binary_search(&t).is_err() {
-                                            panic::trait_not_used(t);
+                                    if traits.binary_search(&t).is_err() {
+                                        panic::trait_not_used(t);
+                                    }
+
+                                    if t == Trait::Hash {
+                                        if result.is_some() {
+                                            panic::reuse_a_trait(t);
                                         }
 
-                                        if t == Trait::Hash {
-                                            if result.is_some() {
-                                                panic::reuse_a_trait(t);
-                                            }
-
-                                            result = Some(self.from_hash_meta(meta));
-                                        }
-                                    },
-                                    _ => panic::educe_format_incorrect(),
-                                }
+                                        result = Some(self.from_hash_meta(meta));
+                                    }
+                                },
+                                _ => panic::educe_format_incorrect(),
                             }
-                        },
-                        _ => panic::educe_format_incorrect(),
-                    }
+                        }
+                    },
+                    _ => panic::educe_format_incorrect(),
                 }
             }
         }

--- a/src/trait_handlers/ord/models/field_attribute.rs
+++ b/src/trait_handlers/ord/models/field_attribute.rs
@@ -312,11 +312,9 @@ impl FieldAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-            let meta_name = meta.path().into_token_stream().to_string();
-
-            if meta_name.as_str() == "educe" {
                 match meta {
                     Meta::List(list) => {
                         for p in list.nested.iter() {

--- a/src/trait_handlers/ord/models/type_attribute.rs
+++ b/src/trait_handlers/ord/models/type_attribute.rs
@@ -261,37 +261,35 @@ impl TypeAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            if let Some(meta_name) = attribute.path.get_ident() {
-                if meta_name == "educe" {
-                    let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-                    match meta {
-                        Meta::List(list) => {
-                            for p in list.nested.iter() {
-                                match p {
-                                    NestedMeta::Meta(meta) => {
-                                        let meta_name = meta.path().into_token_stream().to_string();
+                match meta {
+                    Meta::List(list) => {
+                        for p in list.nested.iter() {
+                            match p {
+                                NestedMeta::Meta(meta) => {
+                                    let meta_name = meta.path().into_token_stream().to_string();
 
-                                        let t = Trait::from_str(meta_name);
+                                    let t = Trait::from_str(meta_name);
 
-                                        if traits.binary_search(&t).is_err() {
-                                            panic::trait_not_used(t);
+                                    if traits.binary_search(&t).is_err() {
+                                        panic::trait_not_used(t);
+                                    }
+
+                                    if t == Trait::Ord {
+                                        if result.is_some() {
+                                            panic::reuse_a_trait(t);
                                         }
 
-                                        if t == Trait::Ord {
-                                            if result.is_some() {
-                                                panic::reuse_a_trait(t);
-                                            }
-
-                                            result = Some(self.from_ord_meta(meta));
-                                        }
-                                    },
-                                    _ => panic::educe_format_incorrect(),
-                                }
+                                        result = Some(self.from_ord_meta(meta));
+                                    }
+                                },
+                                _ => panic::educe_format_incorrect(),
                             }
-                        },
-                        _ => panic::educe_format_incorrect(),
-                    }
+                        }
+                    },
+                    _ => panic::educe_format_incorrect(),
                 }
             }
         }

--- a/src/trait_handlers/partial_eq/models/field_attribute.rs
+++ b/src/trait_handlers/partial_eq/models/field_attribute.rs
@@ -242,11 +242,9 @@ impl FieldAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-            let meta_name = meta.path().into_token_stream().to_string();
-
-            if meta_name.as_str() == "educe" {
                 match meta {
                     Meta::List(list) => {
                         for p in list.nested.iter() {

--- a/src/trait_handlers/partial_eq/models/type_attribute.rs
+++ b/src/trait_handlers/partial_eq/models/type_attribute.rs
@@ -198,37 +198,35 @@ impl TypeAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            if let Some(meta_name) = attribute.path.get_ident() {
-                if meta_name == "educe" {
-                    let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-                    match meta {
-                        Meta::List(list) => {
-                            for p in list.nested.iter() {
-                                match p {
-                                    NestedMeta::Meta(meta) => {
-                                        let meta_name = meta.path().into_token_stream().to_string();
+                match meta {
+                    Meta::List(list) => {
+                        for p in list.nested.iter() {
+                            match p {
+                                NestedMeta::Meta(meta) => {
+                                    let meta_name = meta.path().into_token_stream().to_string();
 
-                                        let t = Trait::from_str(meta_name);
+                                    let t = Trait::from_str(meta_name);
 
-                                        if traits.binary_search(&t).is_err() {
-                                            panic::trait_not_used(t);
+                                    if traits.binary_search(&t).is_err() {
+                                        panic::trait_not_used(t);
+                                    }
+
+                                    if t == Trait::PartialEq {
+                                        if result.is_some() {
+                                            panic::reuse_a_trait(t);
                                         }
 
-                                        if t == Trait::PartialEq {
-                                            if result.is_some() {
-                                                panic::reuse_a_trait(t);
-                                            }
-
-                                            result = Some(self.from_partial_eq_meta(meta));
-                                        }
-                                    },
-                                    _ => panic::educe_format_incorrect(),
-                                }
+                                        result = Some(self.from_partial_eq_meta(meta));
+                                    }
+                                },
+                                _ => panic::educe_format_incorrect(),
                             }
-                        },
-                        _ => panic::educe_format_incorrect(),
-                    }
+                        }
+                    },
+                    _ => panic::educe_format_incorrect(),
                 }
             }
         }

--- a/src/trait_handlers/partial_ord/models/field_attribute.rs
+++ b/src/trait_handlers/partial_ord/models/field_attribute.rs
@@ -315,11 +315,9 @@ impl FieldAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-            let meta_name = meta.path().into_token_stream().to_string();
-
-            if meta_name.as_str() == "educe" {
                 match meta {
                     Meta::List(list) => {
                         for p in list.nested.iter() {

--- a/src/trait_handlers/partial_ord/models/type_attribute.rs
+++ b/src/trait_handlers/partial_ord/models/type_attribute.rs
@@ -265,37 +265,35 @@ impl TypeAttributeBuilder {
         let mut result = None;
 
         for attribute in attributes.iter() {
-            if let Some(meta_name) = attribute.path.get_ident() {
-                if meta_name == "educe" {
-                    let meta = attribute.parse_meta().unwrap();
+            if attribute.path.is_ident("educe") {
+                let meta = attribute.parse_meta().unwrap();
 
-                    match meta {
-                        Meta::List(list) => {
-                            for p in list.nested.iter() {
-                                match p {
-                                    NestedMeta::Meta(meta) => {
-                                        let meta_name = meta.path().into_token_stream().to_string();
+                match meta {
+                    Meta::List(list) => {
+                        for p in list.nested.iter() {
+                            match p {
+                                NestedMeta::Meta(meta) => {
+                                    let meta_name = meta.path().into_token_stream().to_string();
 
-                                        let t = Trait::from_str(meta_name);
+                                    let t = Trait::from_str(meta_name);
 
-                                        if traits.binary_search(&t).is_err() {
-                                            panic::trait_not_used(t);
+                                    if traits.binary_search(&t).is_err() {
+                                        panic::trait_not_used(t);
+                                    }
+
+                                    if t == Trait::PartialOrd {
+                                        if result.is_some() {
+                                            panic::reuse_a_trait(t);
                                         }
 
-                                        if t == Trait::PartialOrd {
-                                            if result.is_some() {
-                                                panic::reuse_a_trait(t);
-                                            }
-
-                                            result = Some(self.from_partial_ord_meta(meta));
-                                        }
-                                    },
-                                    _ => panic::educe_format_incorrect(),
-                                }
+                                        result = Some(self.from_partial_ord_meta(meta));
+                                    }
+                                },
+                                _ => panic::educe_format_incorrect(),
                             }
-                        },
-                        _ => panic::educe_format_incorrect(),
-                    }
+                        }
+                    },
+                    _ => panic::educe_format_incorrect(),
                 }
             }
         }


### PR DESCRIPTION
Now parse meta is run after checking the path every time.

Fixes #9