### PR TITLE
Avoid name clashes with field names

### DIFF
--- a/src/trait_handlers/clone/clone_enum.rs
+++ b/src/trait_handlers/clone/clone_enum.rs
@@ -74,7 +74,7 @@ impl TraitHandler for CloneEnumHandler {
             if variants.is_empty() {
                 if !contains_copy {
                     clone_token_stream.extend(quote!(unreachable!()));
-                    clone_from_token_stream.extend(quote!(let _ = v_source_;));
+                    clone_from_token_stream.extend(quote!(let _ = source;));
                 }
             } else {
                 let mut clone_variants_token_stream = proc_macro2::TokenStream::new();
@@ -90,10 +90,10 @@ impl TraitHandler for CloneEnumHandler {
                             });
                             clone_from_variants_token_stream.extend(quote! {
                                 Self::#variant_ident => {
-                                    if let Self::#variant_ident = v_source_ {
+                                    if let Self::#variant_ident = source {
                                         // same
                                     } else {
-                                        *self = ::core::clone::Clone::clone(v_source_);
+                                        *self = ::core::clone::Clone::clone(source);
                                     }
                                 },
                             });
@@ -127,7 +127,7 @@ impl TraitHandler for CloneEnumHandler {
                                         #field_name: ::core::clone::Clone::clone(#field_name),
                                     });
                                     body_token_stream.extend(
-                                quote!( ::core::clone::Clone::clone_from(#field_name, #field_name2); ),
+                                        quote!( ::core::clone::Clone::clone_from(#field_name, #field_name2); ),
                                     );
                                 }
                             }
@@ -138,10 +138,10 @@ impl TraitHandler for CloneEnumHandler {
 
                             clone_from_variants_token_stream.extend(quote! {
                                     Self::#variant_ident { #pattern_token_stream } => {
-                                        if let Self::#variant_ident { #pattern2_token_stream } = v_source_ {
+                                        if let Self::#variant_ident { #pattern2_token_stream } = source {
                                             #body_token_stream
                                         } else {
-                                            *self = ::core::clone::Clone::clone(v_source_);
+                                            *self = ::core::clone::Clone::clone(source);
                                         }
                                     },
                                 });
@@ -182,18 +182,18 @@ impl TraitHandler for CloneEnumHandler {
                             }
 
                             clone_variants_token_stream.extend(quote! {
-                                Self::#variant_ident ( #pattern_token_stream ) => Self::#variant_ident ( #fields_token_stream ),
-                            });
+                                    Self::#variant_ident ( #pattern_token_stream ) => Self::#variant_ident ( #fields_token_stream ),
+                                });
 
                             clone_from_variants_token_stream.extend(quote! {
-                                Self::#variant_ident ( #pattern_token_stream ) => {
-                                    if let Self::#variant_ident ( #pattern2_token_stream ) = v_source_ {
-                                        #body_token_stream
-                                    } else {
-                                        *self = ::core::clone::Clone::clone(v_source_);
-                                    }
-                                },
-                            });
+                                    Self::#variant_ident ( #pattern_token_stream ) => {
+                                        if let Self::#variant_ident ( #pattern2_token_stream ) = source {
+                                            #body_token_stream
+                                        } else {
+                                            *self = ::core::clone::Clone::clone(source);
+                                        }
+                                    },
+                                });
                         },
                     }
                 }
@@ -231,7 +231,7 @@ impl TraitHandler for CloneEnumHandler {
         } else {
             Some(quote! {
                 #[inline]
-                fn clone_from(&mut self, v_source_: &Self) {
+                fn clone_from(&mut self, source: &Self) {
                     #clone_from_token_stream
                 }
             })

--- a/src/trait_handlers/clone/clone_struct.rs
+++ b/src/trait_handlers/clone/clone_struct.rs
@@ -54,7 +54,7 @@ impl TraitHandler for CloneStructHandler {
                 Fields::Unit => {
                     if !contains_copy {
                         clone_token_stream.extend(quote!(Self));
-                        clone_from_token_stream.extend(quote!(let _ = v_source_;));
+                        clone_from_token_stream.extend(quote!(let _ = source;));
                     }
                 },
                 Fields::Named(_) => {
@@ -62,7 +62,7 @@ impl TraitHandler for CloneStructHandler {
                     let mut clone_from_body_token_stream = proc_macro2::TokenStream::new();
 
                     if fields.is_empty() {
-                        clone_from_body_token_stream.extend(quote!(let _ = v_source_;));
+                        clone_from_body_token_stream.extend(quote!(let _ = source;));
                     } else {
                         for (field, field_attribute) in fields {
                             let field_name = field.ident.as_ref().unwrap();
@@ -73,7 +73,7 @@ impl TraitHandler for CloneStructHandler {
                                 });
 
                                 clone_from_body_token_stream.extend(
-                                    quote!(self.#field_name = #clone(&v_source_.#field_name);),
+                                    quote!(self.#field_name = #clone(&source.#field_name);),
                                 );
                             } else {
                                 clone_types.push(&field.ty);
@@ -83,8 +83,8 @@ impl TraitHandler for CloneStructHandler {
                                 });
 
                                 clone_from_body_token_stream.extend(
-                            quote!( ::core::clone::Clone::clone_from(&mut self.#field_name, &v_source_.#field_name); ),
-                                );
+                                        quote!( ::core::clone::Clone::clone_from(&mut self.#field_name, &source.#field_name); ),
+                                    );
                             }
                         }
                     }
@@ -104,7 +104,7 @@ impl TraitHandler for CloneStructHandler {
                     let mut clone_from_body_token_stream = proc_macro2::TokenStream::new();
 
                     if fields.is_empty() {
-                        clone_from_body_token_stream.extend(quote!(let _ = v_source_;));
+                        clone_from_body_token_stream.extend(quote!(let _ = source;));
                     } else {
                         for (index, (field, field_attribute)) in fields.into_iter().enumerate() {
                             let field_name = Index::from(index);
@@ -113,7 +113,7 @@ impl TraitHandler for CloneStructHandler {
                                 fields_token_stream.extend(quote!(#clone(&self.#field_name),));
 
                                 clone_from_body_token_stream.extend(
-                                    quote!(self.#field_name = #clone(&v_source_.#field_name);),
+                                    quote!(self.#field_name = #clone(&source.#field_name);),
                                 );
                             } else {
                                 clone_types.push(&field.ty);
@@ -123,8 +123,8 @@ impl TraitHandler for CloneStructHandler {
                                 );
 
                                 clone_from_body_token_stream.extend(
-                            quote!( ::core::clone::Clone::clone_from(&mut self.#field_name, &v_source_.#field_name); ),
-                                );
+                                        quote!( ::core::clone::Clone::clone_from(&mut self.#field_name, &source.#field_name); ),
+                                    );
                             }
                         }
                     }
@@ -154,7 +154,7 @@ impl TraitHandler for CloneStructHandler {
         } else {
             Some(quote! {
                 #[inline]
-                fn clone_from(&mut self, v_source_: &Self) {
+                fn clone_from(&mut self, source: &Self) {
                     #clone_from_token_stream
                 }
             })

--- a/src/trait_handlers/debug/common.rs
+++ b/src/trait_handlers/debug/common.rs
@@ -12,12 +12,12 @@ pub(crate) fn create_debug_map_builder() -> proc_macro2::TokenStream {
 
         impl ::core::fmt::Debug for RawString {
             #[inline]
-            fn fmt(&self, v_formatter_: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                v_formatter_.write_str(self.0)
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                f.write_str(self.0)
             }
         }
 
-        let mut builder = v_formatter_.debug_map();
+        let mut builder = f.debug_map();
     )
 }
 
@@ -52,8 +52,8 @@ pub(crate) fn create_format_arg(
 
             impl<'a, #filtered_params> ::core::fmt::Debug for MyDebug<'a, #filtered_params> {
                 #[inline]
-                fn fmt(&self, v_formatter_: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    #format_method(self.0, v_formatter_)
+                fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                    #format_method(self.0, f)
                 }
             }
 

--- a/src/trait_handlers/debug/debug_enum.rs
+++ b/src/trait_handlers/debug/debug_enum.rs
@@ -67,9 +67,8 @@ impl TraitHandler for DebugEnumHandler {
                             return Err(super::panic::unit_variant_need_name(variant));
                         }
 
-                        arms_token_stream.extend(
-                            quote!( Self::#variant_ident => v_formatter_.write_str(#name_string), ),
-                        );
+                        arms_token_stream
+                            .extend(quote!( Self::#variant_ident => f.write_str(#name_string), ));
                     },
                     Fields::Named(fields) => {
                         let mut has_fields = false;
@@ -133,9 +132,8 @@ impl TraitHandler for DebugEnumHandler {
                                 has_fields = true;
                             }
                         } else {
-                            block_token_stream.extend(
-                                quote!(let mut builder = v_formatter_.debug_tuple(#name_string);),
-                            );
+                            block_token_stream
+                                .extend(quote!(let mut builder = f.debug_tuple(#name_string);));
 
                             for field in fields.named.iter() {
                                 let field_attribute = FieldAttributeBuilder {
@@ -252,9 +250,8 @@ impl TraitHandler for DebugEnumHandler {
                                 has_fields = true;
                             }
                         } else {
-                            block_token_stream.extend(
-                                quote!(let mut builder = v_formatter_.debug_tuple(#name_string);),
-                            );
+                            block_token_stream
+                                .extend(quote!(let mut builder = f.debug_tuple(#name_string);));
 
                             for (index, field) in fields.unnamed.iter().enumerate() {
                                 let field_attribute = FieldAttributeBuilder {
@@ -318,7 +315,7 @@ impl TraitHandler for DebugEnumHandler {
         if arms_token_stream.is_empty() {
             if let Some(ident) = name {
                 builder_token_stream.extend(quote! {
-                    v_formatter_.write_str(stringify!(#ident))
+                    f.write_str(stringify!(#ident))
                 });
             } else {
                 return Err(super::panic::unit_enum_need_name(ident));
@@ -349,7 +346,7 @@ impl TraitHandler for DebugEnumHandler {
         token_stream.extend(quote! {
             impl #impl_generics ::core::fmt::Debug for #ident #ty_generics #where_clause {
                 #[inline]
-                fn fmt(&self, v_formatter_: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     #builder_token_stream
                 }
             }
@@ -362,7 +359,7 @@ impl TraitHandler for DebugEnumHandler {
 #[inline]
 fn create_named_field_builder(name_string: Option<&str>) -> proc_macro2::TokenStream {
     if let Some(name_string) = name_string {
-        quote!(let mut builder = v_formatter_.debug_struct(#name_string);)
+        quote!(let mut builder = f.debug_struct(#name_string);)
     } else {
         super::common::create_debug_map_builder()
     }

--- a/src/trait_handlers/debug/debug_enum.rs
+++ b/src/trait_handlers/debug/debug_enum.rs
@@ -214,15 +214,15 @@ impl TraitHandler for DebugEnumHandler {
                                     continue;
                                 }
 
-                                let field_name: Ident =
+                                let field_name_var: Ident =
                                     syn::parse_str(&format!("_{}", index)).unwrap();
 
                                 let key = match field_attribute.name {
                                     FieldName::Custom(name) => name,
-                                    FieldName::Default => field_name.clone(),
+                                    FieldName::Default => field_name_var.clone(),
                                 };
 
-                                pattern_token_stream.extend(quote!(#field_name,));
+                                pattern_token_stream.extend(quote!(#field_name_var,));
 
                                 let ty = &field.ty;
 
@@ -231,7 +231,7 @@ impl TraitHandler for DebugEnumHandler {
                                         &ast.generics.params,
                                         ty,
                                         &method,
-                                        quote!(#field_name),
+                                        quote!(#field_name_var),
                                     ));
 
                                     block_token_stream.extend(if name_string.is_some() {
@@ -243,9 +243,9 @@ impl TraitHandler for DebugEnumHandler {
                                     debug_types.push(ty);
 
                                     block_token_stream.extend(if name_string.is_some() {
-                                        quote! (builder.field(stringify!(#key), #field_name);)
+                                        quote! (builder.field(stringify!(#key), #field_name_var);)
                                     } else {
-                                        quote! (builder.entry(&RawString(stringify!(#key)), #field_name);)
+                                        quote! (builder.entry(&RawString(stringify!(#key)), #field_name_var);)
                                     });
                                 }
 
@@ -270,10 +270,10 @@ impl TraitHandler for DebugEnumHandler {
                                     continue;
                                 }
 
-                                let field_name: Ident =
+                                let field_name_var: Ident =
                                     syn::parse_str(&format!("_{}", index)).unwrap();
 
-                                pattern_token_stream.extend(quote!(#field_name,));
+                                pattern_token_stream.extend(quote!(#field_name_var,));
 
                                 let ty = &field.ty;
 
@@ -282,14 +282,14 @@ impl TraitHandler for DebugEnumHandler {
                                         &ast.generics.params,
                                         ty,
                                         &method,
-                                        quote!(#field_name),
+                                        quote!(#field_name_var),
                                     ));
 
                                     block_token_stream.extend(quote! (builder.field(&arg);));
                                 } else {
                                     debug_types.push(ty);
 
-                                    block_token_stream.extend(quote! (builder.field(#field_name);));
+                                    block_token_stream.extend(quote! (builder.field(#field_name_var);));
                                 }
 
                                 has_fields = true;

--- a/src/trait_handlers/debug/debug_struct.rs
+++ b/src/trait_handlers/debug/debug_struct.rs
@@ -44,7 +44,7 @@ impl TraitHandler for DebugStructHandler {
 
         if type_attribute.named_field {
             builder_token_stream.extend(if let Some(name) = name {
-                quote!(let mut builder = v_formatter_.debug_struct(stringify!(#name));)
+                quote!(let mut builder = f.debug_struct(stringify!(#name));)
             } else {
                 super::common::create_debug_map_builder()
             });
@@ -109,7 +109,7 @@ impl TraitHandler for DebugStructHandler {
             }
         } else {
             builder_token_stream
-                .extend(quote!(let mut builder = v_formatter_.debug_tuple(stringify!(#name));));
+                .extend(quote!(let mut builder = f.debug_tuple(stringify!(#name));));
 
             if let Data::Struct(data) = &ast.data {
                 for (index, field) in data.fields.iter().enumerate() {
@@ -174,7 +174,7 @@ impl TraitHandler for DebugStructHandler {
         token_stream.extend(quote! {
             impl #impl_generics ::core::fmt::Debug for #ident #ty_generics #where_clause {
                 #[inline]
-                fn fmt(&self, v_formatter_: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     #builder_token_stream
 
                     builder.finish()

--- a/src/trait_handlers/debug/debug_union.rs
+++ b/src/trait_handlers/debug/debug_union.rs
@@ -48,7 +48,7 @@ impl TraitHandler for DebugUnionHandler {
 
             if let Some(name) = name {
                 builder_token_stream.extend(quote!(
-                    let mut builder = v_formatter_.debug_tuple(stringify!(#name));
+                    let mut builder = f.debug_tuple(stringify!(#name));
 
                     let size = ::core::mem::size_of::<Self>();
 
@@ -63,7 +63,7 @@ impl TraitHandler for DebugUnionHandler {
                     let size = ::core::mem::size_of::<Self>();
                     let data = unsafe { ::core::slice::from_raw_parts(self as *const Self as *const u8, size) };
 
-                    ::core::fmt::Debug::fmt(data, v_formatter_)
+                    ::core::fmt::Debug::fmt(data, f)
                 ));
             }
         }
@@ -75,7 +75,7 @@ impl TraitHandler for DebugUnionHandler {
         token_stream.extend(quote! {
             impl #impl_generics ::core::fmt::Debug for #ident #ty_generics #where_clause {
                 #[inline]
-                fn fmt(&self, v_formatter_: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                     #builder_token_stream
                 }
             }

--- a/src/trait_handlers/hash/hash_enum.rs
+++ b/src/trait_handlers/hash/hash_enum.rs
@@ -1,4 +1,4 @@
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{Data, DeriveInput, Fields, Ident, Meta, Path, Type};
 
 use super::{
@@ -61,22 +61,23 @@ impl TraitHandler for HashEnumHandler {
                             }
                             .build_from_attributes(&field.attrs, traits)?;
 
-                            let field_name = field.ident.as_ref().unwrap();
+                            let field_name_real = field.ident.as_ref().unwrap();
+                            let field_name_var = format_ident!("v_{}", field_name_real);
 
                             if field_attribute.ignore {
-                                pattern_token_stream.extend(quote!(#field_name: _,));
+                                pattern_token_stream.extend(quote!(#field_name_real: _,));
 
                                 continue;
                             }
 
-                            pattern_token_stream.extend(quote!(#field_name,));
+                            pattern_token_stream.extend(quote!(#field_name_real: #field_name_var,));
 
                             let hash = field_attribute.method.as_ref().unwrap_or_else(|| {
                                 hash_types.push(&field.ty);
                                 &built_in_hash
                             });
 
-                            block_token_stream.extend(quote!( #hash(#field_name, state); ));
+                            block_token_stream.extend(quote!( #hash(#field_name_var, state); ));
                         }
 
                         arms_token_stream.extend(quote! {

--- a/src/trait_handlers/hash/hash_enum.rs
+++ b/src/trait_handlers/hash/hash_enum.rs
@@ -46,7 +46,7 @@ impl TraitHandler for HashEnumHandler {
                     Fields::Unit => {
                         arms_token_stream.extend(quote! {
                             Self::#variant_ident => {
-                                ::core::hash::Hash::hash(&#variant_index, v_state_);
+                                ::core::hash::Hash::hash(&#variant_index, state);
                             }
                         });
                     },
@@ -76,12 +76,12 @@ impl TraitHandler for HashEnumHandler {
                                 &built_in_hash
                             });
 
-                            block_token_stream.extend(quote!( #hash(#field_name, v_state_); ));
+                            block_token_stream.extend(quote!( #hash(#field_name, state); ));
                         }
 
                         arms_token_stream.extend(quote! {
                             Self::#variant_ident { #pattern_token_stream } => {
-                                ::core::hash::Hash::hash(&#variant_index, v_state_);
+                                ::core::hash::Hash::hash(&#variant_index, state);
 
                                 #block_token_stream
                             }
@@ -113,12 +113,12 @@ impl TraitHandler for HashEnumHandler {
                                 &built_in_hash
                             });
 
-                            block_token_stream.extend(quote!( #hash(#field_name, v_state_); ));
+                            block_token_stream.extend(quote!( #hash(#field_name, state); ));
                         }
 
                         arms_token_stream.extend(quote! {
                             Self::#variant_ident ( #pattern_token_stream ) => {
-                                ::core::hash::Hash::hash(&#variant_index, v_state_);
+                                ::core::hash::Hash::hash(&#variant_index, state);
 
                                 #block_token_stream
                             }
@@ -156,7 +156,7 @@ impl TraitHandler for HashEnumHandler {
         token_stream.extend(quote! {
             impl #impl_generics ::core::hash::Hash for #ident #ty_generics #where_clause {
                 #[inline]
-                fn hash<H: ::core::hash::Hasher>(&self, v_state_: &mut H) {
+                fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
                     #hash_token_stream
                 }
             }

--- a/src/trait_handlers/hash/hash_struct.rs
+++ b/src/trait_handlers/hash/hash_struct.rs
@@ -52,7 +52,7 @@ impl TraitHandler for HashStructHandler {
                     &built_in_hash
                 });
 
-                hash_token_stream.extend(quote!( #hash(&self.#field_name, v_state_); ));
+                hash_token_stream.extend(quote!( #hash(&self.#field_name, state); ));
             }
         }
 
@@ -76,7 +76,7 @@ impl TraitHandler for HashStructHandler {
         token_stream.extend(quote! {
             impl #impl_generics ::core::hash::Hash for #ident #ty_generics #where_clause {
                 #[inline]
-                fn hash<H: ::core::hash::Hasher>(&self, v_state_: &mut H) {
+                fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
                     #hash_token_stream
                 }
             }

--- a/src/trait_handlers/hash/hash_union.rs
+++ b/src/trait_handlers/hash/hash_union.rs
@@ -40,11 +40,11 @@ impl TraitHandler for HashUnionHandler {
         token_stream.extend(quote! {
             impl #impl_generics ::core::hash::Hash for #ident #ty_generics #where_clause {
                 #[inline]
-                fn hash<H: ::core::hash::Hasher>(&self, v_state_: &mut H) {
+                fn hash<H: ::core::hash::Hasher>(&self, state: &mut H) {
                     let size = ::core::mem::size_of::<Self>();
                     let data = unsafe { ::core::slice::from_raw_parts(self as *const Self as *const u8, size) };
 
-                    ::core::hash::Hash::hash(data, v_state_)
+                    ::core::hash::Hash::hash(data, state)
                 }
             }
         });

--- a/src/trait_handlers/ord/ord_enum.rs
+++ b/src/trait_handlers/ord/ord_enum.rs
@@ -117,7 +117,7 @@ impl TraitHandler for OrdEnumHandler {
 
                         arms_token_stream.extend(quote! {
                             Self::#variant_ident { #pattern_token_stream } => {
-                                if let Self::#variant_ident { #pattern2_token_stream } = v_other_ {
+                                if let Self::#variant_ident { #pattern2_token_stream } = other {
                                     #block_token_stream
                                 }
                             }
@@ -187,7 +187,7 @@ impl TraitHandler for OrdEnumHandler {
 
                         arms_token_stream.extend(quote! {
                             Self::#variant_ident ( #pattern_token_stream ) => {
-                                if let Self::#variant_ident ( #pattern2_token_stream ) = v_other_ {
+                                if let Self::#variant_ident ( #pattern2_token_stream ) = other {
                                     #block_token_stream
                                 }
                             }
@@ -202,7 +202,7 @@ impl TraitHandler for OrdEnumHandler {
         } else {
             let discriminant_cmp = quote! {
                 unsafe {
-                    ::core::cmp::Ord::cmp(&*<*const _>::from(self).cast::<#discriminant_type>(), &*<*const _>::from(v_other_).cast::<#discriminant_type>())
+                    ::core::cmp::Ord::cmp(&*<*const _>::from(self).cast::<#discriminant_type>(), &*<*const _>::from(other).cast::<#discriminant_type>())
                 }
             };
 
@@ -251,7 +251,7 @@ impl TraitHandler for OrdEnumHandler {
         token_stream.extend(quote! {
             impl #impl_generics ::core::cmp::Ord for #ident #ty_generics #where_clause {
                 #[inline]
-                fn cmp(&self, v_other_: &Self) -> ::core::cmp::Ordering {
+                fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
                     #cmp_token_stream
                 }
             }
@@ -262,8 +262,8 @@ impl TraitHandler for OrdEnumHandler {
             token_stream.extend(quote! {
                 impl #impl_generics ::core::cmp::PartialOrd for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn partial_cmp(&self, v_other_: &Self) -> Option<::core::cmp::Ordering> {
-                        Some(::core::cmp::Ord::cmp(self, v_other_))
+                    fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
+                        Some(::core::cmp::Ord::cmp(self, other))
                     }
                 }
             });

--- a/src/trait_handlers/ord/ord_struct.rs
+++ b/src/trait_handlers/ord/ord_struct.rs
@@ -68,7 +68,7 @@ impl TraitHandler for OrdStructHandler {
                 });
 
                 cmp_token_stream.extend(quote! {
-                    match #cmp(&self.#field_name, &v_other_.#field_name) {
+                    match #cmp(&self.#field_name, &other.#field_name) {
                         ::core::cmp::Ordering::Equal => (),
                         ::core::cmp::Ordering::Greater => return ::core::cmp::Ordering::Greater,
                         ::core::cmp::Ordering::Less => return ::core::cmp::Ordering::Less,
@@ -97,7 +97,7 @@ impl TraitHandler for OrdStructHandler {
         token_stream.extend(quote! {
             impl #impl_generics ::core::cmp::Ord for #ident #ty_generics #where_clause {
                 #[inline]
-                fn cmp(&self, v_other_: &Self) -> ::core::cmp::Ordering {
+                fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
                     #cmp_token_stream
 
                     ::core::cmp::Ordering::Equal
@@ -110,8 +110,8 @@ impl TraitHandler for OrdStructHandler {
             token_stream.extend(quote! {
                 impl #impl_generics ::core::cmp::PartialOrd for #ident #ty_generics #where_clause {
                     #[inline]
-                    fn partial_cmp(&self, v_other_: &Self) -> Option<::core::cmp::Ordering> {
-                        Some(::core::cmp::Ord::cmp(self, v_other_))
+                    fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
+                        Some(::core::cmp::Ord::cmp(self, other))
                     }
                 }
             });

--- a/src/trait_handlers/partial_eq/partial_eq_enum.rs
+++ b/src/trait_handlers/partial_eq/partial_eq_enum.rs
@@ -44,7 +44,7 @@ impl TraitHandler for PartialEqEnumHandler {
                     Fields::Unit => {
                         arms_token_stream.extend(quote! {
                             Self::#variant_ident => {
-                                if let Self::#variant_ident = v_other_ {
+                                if let Self::#variant_ident = other {
                                     // same
                                 } else {
                                     return false;
@@ -100,7 +100,7 @@ impl TraitHandler for PartialEqEnumHandler {
 
                         arms_token_stream.extend(quote! {
                             Self::#variant_ident { #pattern_token_stream } => {
-                                if let Self::#variant_ident { #pattern2_token_stream } = v_other_ {
+                                if let Self::#variant_ident { #pattern2_token_stream } = other {
                                     #block_token_stream
                                 } else {
                                     return false;
@@ -156,7 +156,7 @@ impl TraitHandler for PartialEqEnumHandler {
 
                         arms_token_stream.extend(quote! {
                             Self::#variant_ident ( #pattern_token_stream ) => {
-                                if let Self::#variant_ident ( #pattern2_token_stream ) = v_other_ {
+                                if let Self::#variant_ident ( #pattern2_token_stream ) = other {
                                     #block_token_stream
                                 } else {
                                     return false;
@@ -196,7 +196,7 @@ impl TraitHandler for PartialEqEnumHandler {
         token_stream.extend(quote! {
             impl #impl_generics ::core::cmp::PartialEq for #ident #ty_generics #where_clause {
                 #[inline]
-                fn eq(&self, v_other_: &Self) -> bool {
+                fn eq(&self, other: &Self) -> bool {
                     #eq_token_stream
 
                     true

--- a/src/trait_handlers/partial_eq/partial_eq_enum.rs
+++ b/src/trait_handlers/partial_eq/partial_eq_enum.rs
@@ -1,4 +1,4 @@
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{Data, DeriveInput, Fields, Ident, Meta, Type};
 
 use super::{
@@ -53,8 +53,8 @@ impl TraitHandler for PartialEqEnumHandler {
                         });
                     },
                     Fields::Named(_) => {
-                        let mut pattern_token_stream = proc_macro2::TokenStream::new();
-                        let mut pattern2_token_stream = proc_macro2::TokenStream::new();
+                        let mut pattern_self_token_stream = proc_macro2::TokenStream::new();
+                        let mut pattern_other_token_stream = proc_macro2::TokenStream::new();
                         let mut block_token_stream = proc_macro2::TokenStream::new();
 
                         for field in variant.fields.iter() {
@@ -64,24 +64,23 @@ impl TraitHandler for PartialEqEnumHandler {
                             }
                             .build_from_attributes(&field.attrs, traits)?;
 
-                            let field_name = field.ident.as_ref().unwrap();
+                            let field_name_real = field.ident.as_ref().unwrap();
+                            let field_name_var_self = format_ident!("_s_{}", field_name_real);
+                            let field_name_var_other = format_ident!("_o_{}", field_name_real);
 
                             if field_attribute.ignore {
-                                pattern_token_stream.extend(quote!(#field_name: _,));
-                                pattern2_token_stream.extend(quote!(#field_name: _,));
+                                pattern_self_token_stream.extend(quote!(#field_name_real: _,));
+                                pattern_other_token_stream.extend(quote!(#field_name_real: _,));
 
                                 continue;
                             }
 
-                            let field_name2: Ident =
-                                syn::parse_str(&format!("_{}", field_name)).unwrap();
-
-                            pattern_token_stream.extend(quote!(#field_name,));
-                            pattern2_token_stream.extend(quote!(#field_name: #field_name2,));
+                            pattern_self_token_stream.extend(quote!(#field_name_real: #field_name_var_self,));
+                            pattern_other_token_stream.extend(quote!(#field_name_real: #field_name_var_other,));
 
                             if let Some(method) = field_attribute.method {
                                 block_token_stream.extend(quote! {
-                                    if !#method(#field_name, #field_name2) {
+                                    if !#method(#field_name_var_self, #field_name_var_other) {
                                         return false;
                                     }
                                 });
@@ -91,7 +90,7 @@ impl TraitHandler for PartialEqEnumHandler {
                                 partial_eq_types.push(ty);
 
                                 block_token_stream.extend(quote! {
-                                    if ::core::cmp::PartialEq::ne(#field_name, #field_name2) {
+                                    if ::core::cmp::PartialEq::ne(#field_name_var_self, #field_name_var_other) {
                                         return false;
                                     }
                                 });
@@ -99,8 +98,8 @@ impl TraitHandler for PartialEqEnumHandler {
                         }
 
                         arms_token_stream.extend(quote! {
-                            Self::#variant_ident { #pattern_token_stream } => {
-                                if let Self::#variant_ident { #pattern2_token_stream } = other {
+                            Self::#variant_ident { #pattern_self_token_stream } => {
+                                if let Self::#variant_ident { #pattern_other_token_stream } = other {
                                     #block_token_stream
                                 } else {
                                     return false;

--- a/src/trait_handlers/partial_eq/partial_eq_struct.rs
+++ b/src/trait_handlers/partial_eq/partial_eq_struct.rs
@@ -43,7 +43,7 @@ impl TraitHandler for PartialEqStructHandler {
 
                 if let Some(method) = field_attribute.method {
                     eq_token_stream.extend(quote! {
-                        if !#method(&self.#field_name, &v_other_.#field_name) {
+                        if !#method(&self.#field_name, &other.#field_name) {
                             return false;
                         }
                     });
@@ -53,7 +53,7 @@ impl TraitHandler for PartialEqStructHandler {
                     partial_eq_types.push(ty);
 
                     eq_token_stream.extend(quote! {
-                        if ::core::cmp::PartialEq::ne(&self.#field_name, &v_other_.#field_name) {
+                        if ::core::cmp::PartialEq::ne(&self.#field_name, &other.#field_name) {
                             return false;
                         }
                     });
@@ -81,7 +81,7 @@ impl TraitHandler for PartialEqStructHandler {
         token_stream.extend(quote! {
             impl #impl_generics ::core::cmp::PartialEq for #ident #ty_generics #where_clause {
                 #[inline]
-                fn eq(&self, v_other_: &Self) -> bool {
+                fn eq(&self, other: &Self) -> bool {
                     #eq_token_stream
 
                     true

--- a/src/trait_handlers/partial_eq/partial_eq_union.rs
+++ b/src/trait_handlers/partial_eq/partial_eq_union.rs
@@ -40,10 +40,10 @@ impl TraitHandler for PartialEqUnionHandler {
         token_stream.extend(quote! {
             impl #impl_generics ::core::cmp::PartialEq for #ident #ty_generics #where_clause {
                 #[inline]
-                fn eq(&self, v_other_: &Self) -> bool {
+                fn eq(&self, other: &Self) -> bool {
                     let size = ::core::mem::size_of::<Self>();
                     let self_data = unsafe { ::core::slice::from_raw_parts(self as *const Self as *const u8, size) };
-                    let other_data = unsafe { ::core::slice::from_raw_parts(v_other_ as *const Self as *const u8, size) };
+                    let other_data = unsafe { ::core::slice::from_raw_parts(other as *const Self as *const u8, size) };
 
                     ::core::cmp::PartialEq::eq(self_data, other_data)
                 }

--- a/src/trait_handlers/partial_ord/partial_ord_enum.rs
+++ b/src/trait_handlers/partial_ord/partial_ord_enum.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{spanned::Spanned, Data, DeriveInput, Field, Fields, Ident, Meta, Path, Type};
 
 use super::{
@@ -57,11 +57,11 @@ impl TraitHandler for PartialOrdEnumHandler {
                     Fields::Named(_) => {
                         all_unit = false;
 
-                        let mut pattern_token_stream = proc_macro2::TokenStream::new();
-                        let mut pattern2_token_stream = proc_macro2::TokenStream::new();
+                        let mut pattern_self_token_stream = proc_macro2::TokenStream::new();
+                        let mut pattern_other_token_stream = proc_macro2::TokenStream::new();
                         let mut block_token_stream = proc_macro2::TokenStream::new();
 
-                        let mut fields: BTreeMap<isize, (&Field, &Ident, Ident, FieldAttribute)> =
+                        let mut fields: BTreeMap<isize, (&Field, Ident, Ident, FieldAttribute)> =
                             BTreeMap::new();
 
                         for (index, field) in variant.fields.iter().enumerate() {
@@ -73,20 +73,19 @@ impl TraitHandler for PartialOrdEnumHandler {
                             }
                             .build_from_attributes(&field.attrs, traits)?;
 
-                            let field_name = field.ident.as_ref().unwrap();
+                            let field_name_real = field.ident.as_ref().unwrap();
+                            let field_name_var_self = format_ident!("_s_{}", field_name_real);
+                            let field_name_var_other = format_ident!("_o_{}", field_name_real);
 
                             if field_attribute.ignore {
-                                pattern_token_stream.extend(quote!(#field_name: _,));
-                                pattern2_token_stream.extend(quote!(#field_name: _,));
+                                pattern_self_token_stream.extend(quote!(#field_name_real: _,));
+                                pattern_other_token_stream.extend(quote!(#field_name_real: _,));
 
                                 continue;
                             }
 
-                            let field_name2: Ident =
-                                syn::parse_str(&format!("_{}", field_name)).unwrap();
-
-                            pattern_token_stream.extend(quote!(#field_name,));
-                            pattern2_token_stream.extend(quote!(#field_name: #field_name2,));
+                            pattern_self_token_stream.extend(quote!(#field_name_real: #field_name_var_self,));
+                            pattern_other_token_stream.extend(quote!(#field_name_real: #field_name_var_other,));
 
                             let rank = field_attribute.rank;
 
@@ -97,10 +96,10 @@ impl TraitHandler for PartialOrdEnumHandler {
                                 ));
                             }
 
-                            fields.insert(rank, (field, field_name, field_name2, field_attribute));
+                            fields.insert(rank, (field, field_name_var_self, field_name_var_other, field_attribute));
                         }
 
-                        for (field, field_name, field_name2, field_attribute) in fields.values() {
+                        for (field, field_name_var_self, field_name_var_other, field_attribute) in fields.values() {
                             let partial_cmp =
                                 field_attribute.method.as_ref().unwrap_or_else(|| {
                                     partial_ord_types.push(&field.ty);
@@ -109,7 +108,7 @@ impl TraitHandler for PartialOrdEnumHandler {
                                 });
 
                             block_token_stream.extend(quote! {
-                                match #partial_cmp(#field_name, #field_name2) {
+                                match #partial_cmp(#field_name_var_self, #field_name_var_other) {
                                     Some(::core::cmp::Ordering::Equal) => (),
                                     Some(::core::cmp::Ordering::Greater) => return Some(::core::cmp::Ordering::Greater),
                                     Some(::core::cmp::Ordering::Less) => return Some(::core::cmp::Ordering::Less),
@@ -119,8 +118,8 @@ impl TraitHandler for PartialOrdEnumHandler {
                         }
 
                         arms_token_stream.extend(quote! {
-                            Self::#variant_ident { #pattern_token_stream } => {
-                                if let Self::#variant_ident { #pattern2_token_stream } = other {
+                            Self::#variant_ident { #pattern_self_token_stream } => {
+                                if let Self::#variant_ident { #pattern_other_token_stream } = other {
                                     #block_token_stream
                                 }
                             }

--- a/src/trait_handlers/partial_ord/partial_ord_enum.rs
+++ b/src/trait_handlers/partial_ord/partial_ord_enum.rs
@@ -120,7 +120,7 @@ impl TraitHandler for PartialOrdEnumHandler {
 
                         arms_token_stream.extend(quote! {
                             Self::#variant_ident { #pattern_token_stream } => {
-                                if let Self::#variant_ident { #pattern2_token_stream } = v_other_ {
+                                if let Self::#variant_ident { #pattern2_token_stream } = other {
                                     #block_token_stream
                                 }
                             }
@@ -192,7 +192,7 @@ impl TraitHandler for PartialOrdEnumHandler {
 
                         arms_token_stream.extend(quote! {
                             Self::#variant_ident ( #pattern_token_stream ) => {
-                                if let Self::#variant_ident ( #pattern2_token_stream ) = v_other_ {
+                                if let Self::#variant_ident ( #pattern2_token_stream ) = other {
                                     #block_token_stream
                                 }
                             }
@@ -207,7 +207,7 @@ impl TraitHandler for PartialOrdEnumHandler {
         } else {
             let discriminant_cmp = quote! {
                 unsafe {
-                    ::core::cmp::Ord::cmp(&*<*const _>::from(self).cast::<#discriminant_type>(), &*<*const _>::from(v_other_).cast::<#discriminant_type>())
+                    ::core::cmp::Ord::cmp(&*<*const _>::from(self).cast::<#discriminant_type>(), &*<*const _>::from(other).cast::<#discriminant_type>())
                 }
             };
 
@@ -256,7 +256,7 @@ impl TraitHandler for PartialOrdEnumHandler {
         token_stream.extend(quote! {
             impl #impl_generics ::core::cmp::PartialOrd for #ident #ty_generics #where_clause {
                 #[inline]
-                fn partial_cmp(&self, v_other_: &Self) -> Option<::core::cmp::Ordering> {
+                fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
                     #partial_cmp_token_stream
                 }
             }

--- a/src/trait_handlers/partial_ord/partial_ord_struct.rs
+++ b/src/trait_handlers/partial_ord/partial_ord_struct.rs
@@ -69,7 +69,7 @@ impl TraitHandler for PartialOrdStructHandler {
                 });
 
                 partial_cmp_token_stream.extend(quote! {
-                    match #partial_cmp(&self.#field_name, &v_other_.#field_name) {
+                    match #partial_cmp(&self.#field_name, &other.#field_name) {
                         Some(::core::cmp::Ordering::Equal) => (),
                         Some(::core::cmp::Ordering::Greater) => return Some(::core::cmp::Ordering::Greater),
                         Some(::core::cmp::Ordering::Less) => return Some(::core::cmp::Ordering::Less),
@@ -99,7 +99,7 @@ impl TraitHandler for PartialOrdStructHandler {
         token_stream.extend(quote! {
             impl #impl_generics ::core::cmp::PartialOrd for #ident #ty_generics #where_clause {
                 #[inline]
-                fn partial_cmp(&self, v_other_: &Self) -> Option<::core::cmp::Ordering> {
+                fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
                     #partial_cmp_token_stream
 
                     Some(::core::cmp::Ordering::Equal)

--- a/tests/name_clashes.rs
+++ b/tests/name_clashes.rs
@@ -1,0 +1,41 @@
+// These types test that we don't have name clashes between field names
+// and our local variables and parameter names.
+//
+// We don't need to actually use these anywhere - just compiling them shows things are OK.
+#![allow(dead_code)]
+
+use educe::Educe;
+
+#[derive(Educe, Eq)]
+#[educe(Clone, Debug, Hash, Default, PartialEq, PartialOrd, Ord)]
+pub enum NameClashesEnum {
+    #[educe(Default)]
+    TestDefault { },
+    TestClone { source: i16, v_source_: i16, },
+    TestDebug1 { f: i8, v_formatter_: i8, },
+    TestDebug2 { builder: i32, v_builder_: i32, },
+    TestHHash { state: i32, v_state_: i32, },
+    TestPartialEq { other: i64, v_other_: i64, }
+}
+
+#[derive(Educe, Eq)]
+#[educe(Clone, Debug, Hash, Default, PartialEq, PartialOrd, Ord)]
+pub struct NameClashes {
+    source: i16, v_source_: i16,
+    f: i8, v_formatter_: i8,
+    builder: i32, v_builder_: i32,
+    state: i32, v_state_: i32,
+    other: i64, v_other_: i64,
+}
+
+#[derive(Educe)]
+#[educe(Debug(unsafe), Hash(unsafe), PartialEq(unsafe), Default)]
+pub union NameClashesUnion {
+    source: i16, v_source_: i16,
+    f: i8, v_formatter_: i8,
+    builder: i32, v_builder_: i32,
+    state: i32, v_state_: i32,
+    other: i64, v_other_: i64,
+    #[educe(Default)]
+    def: (),
+}


### PR DESCRIPTION
Hi.  This is an alternative approach to #14, which I think fixes the problem definitively.

After 983a143 we still have name clashes if enum fields are things like `v_builder_`.  That's a slightly odd field name, but I don't think it's reasonable to demand that a user of educe avoid it.

In this branch, I:
 * revert the code changes in 983a143
 * fix the implementations of `Debug` `Hash` `Clone` and the comparison traits for enums
 * provide a test case, which fails with 983a143, and also fails with `983a143~`, and passes at the tip of the branch

To fix the enum impls I generally:
 * use `format_ident!` to generate derived names like `_FIELD`.
 * used the names `field_name_real` and `field_name_var` for the actual name, and the local variable name (pattern binding), respectively (rather than, say `field_name` and `field_name2`).
 * where the existing impl already had `field_name2` because it needs two lots of field names in scope, used two `format_ident!` calls to make two lots of `field_name_var_...`
 * sometimes, renamed some variables to give them more descriptive names (e.g. rather than just with and without a `2` suffix)

I looked at the code for structs, and as far as I can see it doesn't bind the struct fields to local variable names, so it's not affected by issues analogous to #14.   I also looked at the implementations of `Default`, `Deref[Mut]` and `Into`.  These don't have any local variables, so although they use the struct field names directly as local variables, they avoid #14.  I think it might be worth considering derived identifiers for these cases too, in case we should ever introduce local variables into the generated code for these - right now doing so would introduce the #14 bug again.  But I'm not sure now is the right time to do that.

Please let me know what you think.