### PR TITLE
Rename RawString to Educe__RawString

### DIFF
--- a/src/trait_handlers/debug/common.rs
+++ b/src/trait_handlers/debug/common.rs
@@ -8,9 +8,10 @@ use crate::common::r#type::{dereference, find_idents_in_type};
 #[inline]
 pub(crate) fn create_debug_map_builder() -> proc_macro2::TokenStream {
     quote!(
-        struct RawString(&'static str);
+        #[allow(non_camel_case_types)] // We're using __ to help avoid clashes.
+        struct Educe__RawString(&'static str);
 
-        impl ::core::fmt::Debug for RawString {
+        impl ::core::fmt::Debug for Educe__RawString {
             #[inline]
             fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 f.write_str(self.0)

--- a/src/trait_handlers/debug/debug_enum.rs
+++ b/src/trait_handlers/debug/debug_enum.rs
@@ -119,7 +119,7 @@ impl TraitHandler for DebugEnumHandler {
                                     block_token_stream.extend(if name_string.is_some() {
                                         quote! (builder.field(stringify!(#key), &arg);)
                                     } else {
-                                        quote! (builder.entry(&RawString(stringify!(#key)), &arg);)
+                                        quote! (builder.entry(&Educe__RawString(stringify!(#key)), &arg);)
                                     });
                                 } else {
                                     debug_types.push(ty);
@@ -127,7 +127,7 @@ impl TraitHandler for DebugEnumHandler {
                                     block_token_stream.extend(if name_string.is_some() {
                                         quote! (builder.field(stringify!(#key), #field_name_var);)
                                     } else {
-                                        quote! (builder.entry(&RawString(stringify!(#key)), #field_name_var);)
+                                        quote! (builder.entry(&Educe__RawString(stringify!(#key)), #field_name_var);)
                                     });
                                 }
 
@@ -239,7 +239,7 @@ impl TraitHandler for DebugEnumHandler {
                                     block_token_stream.extend(if name_string.is_some() {
                                         quote! (builder.field(stringify!(#key), &arg);)
                                     } else {
-                                        quote! (builder.entry(&RawString(stringify!(#key)), &arg);)
+                                        quote! (builder.entry(&Educe__RawString(stringify!(#key)), &arg);)
                                     });
                                 } else {
                                     debug_types.push(ty);
@@ -247,7 +247,7 @@ impl TraitHandler for DebugEnumHandler {
                                     block_token_stream.extend(if name_string.is_some() {
                                         quote! (builder.field(stringify!(#key), #field_name_var);)
                                     } else {
-                                        quote! (builder.entry(&RawString(stringify!(#key)), #field_name_var);)
+                                        quote! (builder.entry(&Educe__RawString(stringify!(#key)), #field_name_var);)
                                     });
                                 }
 

--- a/src/trait_handlers/debug/debug_struct.rs
+++ b/src/trait_handlers/debug/debug_struct.rs
@@ -89,7 +89,7 @@ impl TraitHandler for DebugStructHandler {
                         builder_token_stream.extend(if name.is_some() {
                             quote! (builder.field(stringify!(#key), &arg);)
                         } else {
-                            quote! (builder.entry(&RawString(stringify!(#key)), &arg);)
+                            quote! (builder.entry(&Educe__RawString(stringify!(#key)), &arg);)
                         });
                     } else {
                         debug_types.push(ty);
@@ -97,7 +97,7 @@ impl TraitHandler for DebugStructHandler {
                         builder_token_stream.extend(if name.is_some() {
                             quote! (builder.field(stringify!(#key), &self.#field_name);)
                         } else {
-                            quote! (builder.entry(&RawString(stringify!(#key)), &self.#field_name);)
+                            quote! (builder.entry(&Educe__RawString(stringify!(#key)), &self.#field_name);)
                         });
                     }
 


### PR DESCRIPTION
Addresses the `RawString` part of #18.  (The `MyDebug` part is in #19).

I did a git-grep which I hoped would find other helper structs emitted in the output.  I didn't find any.

It's possible that there are still variable or type name clashes.  I suggest we deal with those as we find them.