### PR TITLE
Implement bound(*) to mean "all generic parameters"

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,29 @@ enum Enum<T, K> {
 
 In the above case, `T` is bound to the `Debug` trait, but `K` is not.
 
+Or, you can have `educe` replicate the behaviour of `std`'s `derive`'s,
+where a bound is produced for *every* generic parameter,
+without regard to how it's used in the structure:
+
+```rust
+#[derive(Educe)]
+#[educe(Debug(bound(*)))]
+struct Struct<T> {
+    #[educe(Debug(ignore))]
+    f: T,
+}
+```
+
+This can be useful if you don't want to make the trait implementation
+part of your permanent public API.
+In this example,
+`Struct<T>` doesn't implement `Debug` unless `T` does.
+I.e., it has a `T: Debug` bound even though that's not needed right now.
+Later we might want to display `f`; we wouldn't then need to make
+a breaking API change by adding the bound.
+
+This was the behaviour of `Trait(bound)` in educe 0.4.x and earlier.
+
 ###### Union
 
 A union will be formatted as a `u8` slice because we don't know its fields at runtime. The fields of a union cannot be ignored, renamed, or formatted with other methods. The implementation is **unsafe** because it may expose uninitialized memory.

--- a/src/common/bound.rs
+++ b/src/common/bound.rs
@@ -1,7 +1,6 @@
 use syn::{punctuated::Punctuated, token::Comma, GenericParam, Meta, Path, Type, WherePredicate};
 
 use crate::common::where_predicates_bool::{
-    create_where_predicates_from_generic_parameters,
     create_where_predicates_from_generic_parameters_check_types, meta_2_where_predicates,
     WherePredicates, WherePredicatesOrBool,
 };
@@ -33,19 +32,6 @@ impl Bound {
 }
 
 impl Bound {
-    #[inline]
-    pub(crate) fn into_where_predicates_by_generic_parameters(
-        self,
-        params: &Punctuated<GenericParam, Comma>,
-        bound_trait: &Path,
-    ) -> Punctuated<WherePredicate, Comma> {
-        match self {
-            Self::Disabled => Punctuated::new(),
-            Self::Auto => create_where_predicates_from_generic_parameters(params, bound_trait),
-            Self::Custom(where_predicates) => where_predicates,
-        }
-    }
-
     #[inline]
     pub(crate) fn into_where_predicates_by_generic_parameters_check_types(
         self,

--- a/src/common/bound.rs
+++ b/src/common/bound.rs
@@ -49,18 +49,17 @@ impl Bound {
     #[inline]
     pub(crate) fn into_where_predicates_by_generic_parameters_check_types(
         self,
-        params: &Punctuated<GenericParam, Comma>,
+        _params: &Punctuated<GenericParam, Comma>,
         bound_trait: &Path,
         types: &[&Type],
-        recursive: Option<(bool, bool, bool)>,
+        supertraits: &[proc_macro2::TokenStream],
     ) -> Punctuated<WherePredicate, Comma> {
         match self {
             Self::Disabled => Punctuated::new(),
             Self::Auto => create_where_predicates_from_generic_parameters_check_types(
-                params,
                 bound_trait,
                 types,
-                recursive,
+                supertraits,
             ),
             Self::Custom(where_predicates) => where_predicates,
         }

--- a/src/common/bound.rs
+++ b/src/common/bound.rs
@@ -1,6 +1,7 @@
 use syn::{punctuated::Punctuated, token::Comma, GenericParam, Meta, Path, Type, WherePredicate};
 
 use crate::common::where_predicates_bool::{
+    create_where_predicates_from_all_generic_parameters,
     create_where_predicates_from_generic_parameters_check_types, meta_2_where_predicates,
     WherePredicates, WherePredicatesOrBool,
 };
@@ -9,6 +10,7 @@ pub(crate) enum Bound {
     Disabled,
     Auto,
     Custom(WherePredicates),
+    All,
 }
 
 impl Bound {
@@ -27,6 +29,7 @@ impl Bound {
                     Self::Disabled
                 }
             },
+            WherePredicatesOrBool::All => Self::All,
         })
     }
 }
@@ -35,7 +38,7 @@ impl Bound {
     #[inline]
     pub(crate) fn into_where_predicates_by_generic_parameters_check_types(
         self,
-        _params: &Punctuated<GenericParam, Comma>,
+        params: &Punctuated<GenericParam, Comma>,
         bound_trait: &Path,
         types: &[&Type],
         supertraits: &[proc_macro2::TokenStream],
@@ -48,6 +51,7 @@ impl Bound {
                 supertraits,
             ),
             Self::Custom(where_predicates) => where_predicates,
+            Self::All => create_where_predicates_from_all_generic_parameters(params, bound_trait),
         }
     }
 }

--- a/src/common/type.rs
+++ b/src/common/type.rs
@@ -1,9 +1,7 @@
-use std::collections::HashSet;
-
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
-    GenericArgument, Ident, Meta, Path, PathArguments, Token, Type, TypeParamBound,
+    Meta, Token, Type,
 };
 
 pub(crate) struct TypeWithPunctuatedMeta {
@@ -31,115 +29,6 @@ impl Parse for TypeWithPunctuatedMeta {
             ty,
             list,
         })
-    }
-}
-
-/// recursive (dereference, de_ptr, de_param)
-#[inline]
-pub(crate) fn find_idents_in_path<'a>(
-    set: &mut HashSet<&'a Ident>,
-    path: &'a Path,
-    recursive: Option<(bool, bool, bool)>,
-) {
-    if let Some((_, _, de_param)) = recursive {
-        if de_param {
-            if let Some(segment) = path.segments.iter().last() {
-                if let PathArguments::AngleBracketed(a) = &segment.arguments {
-                    // the ident is definitely not a generic parameter, so we don't insert it
-
-                    for arg in a.args.iter() {
-                        match arg {
-                            GenericArgument::Type(ty) => {
-                                find_idents_in_type(set, ty, recursive);
-                            },
-                            GenericArgument::AssocType(ty) => {
-                                find_idents_in_type(set, &ty.ty, recursive);
-                            },
-                            _ => (),
-                        }
-                    }
-
-                    return;
-                }
-            }
-        }
-    }
-
-    if let Some(ty) = path.get_ident() {
-        set.insert(ty);
-    }
-}
-
-/// recursive (dereference, de_ptr, de_param)
-#[inline]
-pub(crate) fn find_idents_in_type<'a>(
-    set: &mut HashSet<&'a Ident>,
-    ty: &'a Type,
-    recursive: Option<(bool, bool, bool)>,
-) {
-    match ty {
-        Type::Array(ty) => {
-            if recursive.is_some() {
-                find_idents_in_type(set, ty.elem.as_ref(), recursive);
-            }
-        },
-        Type::Group(ty) => {
-            if recursive.is_some() {
-                find_idents_in_type(set, ty.elem.as_ref(), recursive);
-            }
-        },
-        Type::ImplTrait(ty) => {
-            // always recursive
-            for b in &ty.bounds {
-                if let TypeParamBound::Trait(ty) = b {
-                    find_idents_in_path(set, &ty.path, recursive);
-                }
-            }
-        },
-        Type::Macro(ty) => {
-            if recursive.is_some() {
-                find_idents_in_path(set, &ty.mac.path, recursive);
-            }
-        },
-        Type::Paren(ty) => {
-            if recursive.is_some() {
-                find_idents_in_type(set, ty.elem.as_ref(), recursive);
-            }
-        },
-        Type::Path(ty) => {
-            find_idents_in_path(set, &ty.path, recursive);
-        },
-        Type::Ptr(ty) => {
-            if let Some((_, true, _)) = recursive {
-                find_idents_in_type(set, ty.elem.as_ref(), recursive);
-            }
-        },
-        Type::Reference(ty) => {
-            if let Some((true, ..)) = recursive {
-                find_idents_in_type(set, ty.elem.as_ref(), recursive);
-            }
-        },
-        Type::Slice(ty) => {
-            if recursive.is_some() {
-                find_idents_in_type(set, ty.elem.as_ref(), recursive);
-            }
-        },
-        Type::TraitObject(ty) => {
-            // always recursive
-            for b in &ty.bounds {
-                if let TypeParamBound::Trait(ty) = b {
-                    find_idents_in_path(set, &ty.path, recursive);
-                }
-            }
-        },
-        Type::Tuple(ty) => {
-            if recursive.is_some() {
-                for ty in &ty.elems {
-                    find_idents_in_type(set, ty, recursive)
-                }
-            }
-        },
-        _ => (),
     }
 }
 

--- a/src/common/where_predicates_bool.rs
+++ b/src/common/where_predicates_bool.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use quote::{quote, ToTokens};
 use syn::{
     parse::{Parse, ParseStream},
@@ -9,7 +7,7 @@ use syn::{
     Expr, GenericParam, Lit, Meta, MetaNameValue, Path, Token, Type, WherePredicate,
 };
 
-use super::{path::path_to_string, r#type::find_idents_in_type};
+use super::path::path_to_string;
 
 pub(crate) type WherePredicates = Punctuated<WherePredicate, Token![,]>;
 
@@ -108,27 +106,15 @@ pub(crate) fn create_where_predicates_from_generic_parameters(
 
 #[inline]
 pub(crate) fn create_where_predicates_from_generic_parameters_check_types(
-    params: &Punctuated<GenericParam, Comma>,
+    _params: &Punctuated<GenericParam, Comma>,
     bound_trait: &Path,
     types: &[&Type],
-    recursive: Option<(bool, bool, bool)>,
+    _recursive: Option<(bool, bool, bool)>,
 ) -> WherePredicates {
     let mut where_predicates = Punctuated::new();
 
-    let mut set = HashSet::new();
-
     for t in types {
-        find_idents_in_type(&mut set, t, recursive);
-    }
-
-    for param in params {
-        if let GenericParam::Type(ty) = param {
-            let ident = &ty.ident;
-
-            if set.contains(ident) {
-                where_predicates.push(syn::parse2(quote! { #ident: #bound_trait }).unwrap());
-            }
-        }
+        where_predicates.push(syn::parse2(quote! { #t: #bound_trait }).unwrap());
     }
 
     where_predicates

--- a/src/common/where_predicates_bool.rs
+++ b/src/common/where_predicates_bool.rs
@@ -87,7 +87,8 @@ pub(crate) fn meta_2_where_predicates(meta: &Meta) -> syn::Result<WherePredicate
 }
 
 #[inline]
-pub(crate) fn create_where_predicates_from_generic_parameters(
+#[allow(dead_code)]
+pub(crate) fn create_where_predicates_from_all_generic_parameters(
     params: &Punctuated<GenericParam, Comma>,
     bound_trait: &Path,
 ) -> WherePredicates {

--- a/src/common/where_predicates_bool.rs
+++ b/src/common/where_predicates_bool.rs
@@ -106,15 +106,18 @@ pub(crate) fn create_where_predicates_from_generic_parameters(
 
 #[inline]
 pub(crate) fn create_where_predicates_from_generic_parameters_check_types(
-    _params: &Punctuated<GenericParam, Comma>,
     bound_trait: &Path,
     types: &[&Type],
-    _recursive: Option<(bool, bool, bool)>,
+    supertraits: &[proc_macro2::TokenStream],
 ) -> WherePredicates {
     let mut where_predicates = Punctuated::new();
 
     for t in types {
         where_predicates.push(syn::parse2(quote! { #t: #bound_trait }).unwrap());
+    }
+
+    for supertrait in supertraits {
+        where_predicates.push(syn::parse2(quote! { Self: #supertrait }).unwrap());
     }
 
     where_predicates

--- a/src/common/where_predicates_bool.rs
+++ b/src/common/where_predicates_bool.rs
@@ -14,6 +14,7 @@ pub(crate) type WherePredicates = Punctuated<WherePredicate, Token![,]>;
 pub(crate) enum WherePredicatesOrBool {
     WherePredicates(WherePredicates),
     Bool(bool),
+    All,
 }
 
 impl Parse for WherePredicatesOrBool {
@@ -31,6 +32,10 @@ impl Parse for WherePredicatesOrBool {
                 },
                 _ => (),
             }
+        }
+
+        if let Ok(_star) = input.parse::<Token![*]>() {
+            return Ok(Self::All);
         }
 
         Ok(Self::WherePredicates(input.parse_terminated(WherePredicate::parse, Token![,])?))
@@ -87,7 +92,6 @@ pub(crate) fn meta_2_where_predicates(meta: &Meta) -> syn::Result<WherePredicate
 }
 
 #[inline]
-#[allow(dead_code)]
 pub(crate) fn create_where_predicates_from_all_generic_parameters(
     params: &Punctuated<GenericParam, Comma>,
     bound_trait: &Path,

--- a/src/trait_handlers/clone/clone_enum.rs
+++ b/src/trait_handlers/clone/clone_enum.rs
@@ -222,7 +222,7 @@ impl TraitHandler for CloneEnumHandler {
                 })
                 .unwrap(),
                 &clone_types,
-                Some((false, false, false)),
+                &[],
             );
         }
 

--- a/src/trait_handlers/clone/clone_struct.rs
+++ b/src/trait_handlers/clone/clone_struct.rs
@@ -145,7 +145,7 @@ impl TraitHandler for CloneStructHandler {
                 })
                 .unwrap(),
                 &clone_types,
-                Some((false, false, false)),
+                &[],
             );
         }
 

--- a/src/trait_handlers/clone/clone_union.rs
+++ b/src/trait_handlers/clone/clone_union.rs
@@ -21,8 +21,11 @@ impl TraitHandler for CloneUnionHandler {
         }
         .build_from_clone_meta(meta)?;
 
+        let mut field_types = vec![];
+
         if let Data::Union(data) = &ast.data {
             for field in data.fields.named.iter() {
+                field_types.push(&field.ty);
                 let _ = FieldAttributeBuilder {
                     enable_method: false
                 }
@@ -32,9 +35,11 @@ impl TraitHandler for CloneUnionHandler {
 
         let ident = &ast.ident;
 
-        let bound = type_attribute.bound.into_where_predicates_by_generic_parameters(
+        let bound = type_attribute.bound.into_where_predicates_by_generic_parameters_check_types(
             &ast.generics.params,
             &syn::parse2(quote!(::core::marker::Copy)).unwrap(),
+            &field_types,
+            &[],
         );
 
         let where_clause = ast.generics.make_where_clause();

--- a/src/trait_handlers/copy/mod.rs
+++ b/src/trait_handlers/copy/mod.rs
@@ -66,12 +66,13 @@ impl TraitHandler for CopyHandler {
 
             let ident = &ast.ident;
 
-            let bound = type_attribute.bound.into_where_predicates_by_generic_parameters_check_types(
-                &ast.generics.params,
-                &syn::parse2(quote!(::core::marker::Copy)).unwrap(),
-                &field_types,
-                &[quote!{::core::clone::Clone}],
-            );
+            let bound =
+                type_attribute.bound.into_where_predicates_by_generic_parameters_check_types(
+                    &ast.generics.params,
+                    &syn::parse2(quote!(::core::marker::Copy)).unwrap(),
+                    &field_types,
+                    &[quote! {::core::clone::Clone}],
+                );
 
             let where_clause = ast.generics.make_where_clause();
 

--- a/src/trait_handlers/debug/common.rs
+++ b/src/trait_handlers/debug/common.rs
@@ -1,9 +1,5 @@
-use std::collections::HashSet;
-
 use quote::quote;
-use syn::{punctuated::Punctuated, token::Comma, DeriveInput, GenericParam, Path, Type};
-
-use crate::common::r#type::{dereference, find_idents_in_type};
+use syn::{DeriveInput, Path, Type};
 
 #[inline]
 pub(crate) fn create_debug_map_builder() -> proc_macro2::TokenStream {
@@ -24,40 +20,35 @@ pub(crate) fn create_debug_map_builder() -> proc_macro2::TokenStream {
 #[inline]
 pub(crate) fn create_format_arg(
     ast: &DeriveInput,
-    ty: &Type,
+    field_ty: &Type,
     format_method: &Path,
-    field: proc_macro2::TokenStream,
+    field_expr: proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
-    let ty = dereference(ty);
+    let ty_ident = &ast.ident;
 
-    let mut idents = HashSet::new();
-    find_idents_in_type(&mut idents, ty, Some((true, true, false)));
-
-    // simply support one level generics (without considering bounds that use other generics)
-    let mut filtered_params: Punctuated<GenericParam, Comma> = Punctuated::new();
-
-    for param in ast.generics.params.iter() {
-        if let GenericParam::Type(ty) = param {
-            let ident = &ty.ident;
-
-            if idents.contains(ident) {
-                filtered_params.push(param.clone());
-            }
-        }
-    }
+    // We use the complete original generics, not filtered by field,
+    // and include a PhantomData<Self> in our wrapper struct to use the generics.
+    //
+    // This avoids having to try to calculate the right *subset* of the generics
+    // relevant for this field, which is nontrivial and maybe impossible.
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
 
     quote!(
         let arg = {
-            struct MyDebug<'a, #filtered_params>(&'a #ty);
+            #[allow(non_camel_case_types)] // We're using __ to help avoid clashes.
+            struct Educe__DebugField<V, M>(V, ::core::marker::PhantomData<M>);
 
-            impl<'a, #filtered_params> ::core::fmt::Debug for MyDebug<'a, #filtered_params> {
+            impl #impl_generics ::core::fmt::Debug
+                for Educe__DebugField<&#field_ty, #ty_ident #ty_generics>
+                #where_clause
+            {
                 #[inline]
-                fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                    #format_method(self.0, f)
+                fn fmt(&self, educe__f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                    #format_method(self.0, educe__f)
                 }
             }
 
-            MyDebug(#field)
+            Educe__DebugField(#field_expr, ::core::marker::PhantomData::<Self>)
         };
     )
 }

--- a/src/trait_handlers/debug/common.rs
+++ b/src/trait_handlers/debug/common.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use quote::quote;
-use syn::{punctuated::Punctuated, token::Comma, GenericParam, Path, Type};
+use syn::{punctuated::Punctuated, token::Comma, DeriveInput, GenericParam, Path, Type};
 
 use crate::common::r#type::{dereference, find_idents_in_type};
 
@@ -23,7 +23,7 @@ pub(crate) fn create_debug_map_builder() -> proc_macro2::TokenStream {
 
 #[inline]
 pub(crate) fn create_format_arg(
-    params: &Punctuated<GenericParam, Comma>,
+    ast: &DeriveInput,
     ty: &Type,
     format_method: &Path,
     field: proc_macro2::TokenStream,
@@ -36,7 +36,7 @@ pub(crate) fn create_format_arg(
     // simply support one level generics (without considering bounds that use other generics)
     let mut filtered_params: Punctuated<GenericParam, Comma> = Punctuated::new();
 
-    for param in params.iter() {
+    for param in ast.generics.params.iter() {
         if let GenericParam::Type(ty) = param {
             let ident = &ty.ident;
 

--- a/src/trait_handlers/debug/debug_enum.rs
+++ b/src/trait_handlers/debug/debug_enum.rs
@@ -336,7 +336,7 @@ impl TraitHandler for DebugEnumHandler {
             &ast.generics.params,
             &syn::parse2(quote!(::core::fmt::Debug)).unwrap(),
             &debug_types,
-            Some((true, false, false)),
+            &[],
         );
 
         let where_clause = ast.generics.make_where_clause();

--- a/src/trait_handlers/debug/debug_enum.rs
+++ b/src/trait_handlers/debug/debug_enum.rs
@@ -110,7 +110,7 @@ impl TraitHandler for DebugEnumHandler {
 
                                 if let Some(method) = field_attribute.method {
                                     block_token_stream.extend(super::common::create_format_arg(
-                                        &ast.generics.params,
+                                        ast,
                                         ty,
                                         &method,
                                         quote!(#field_name_var),
@@ -162,7 +162,7 @@ impl TraitHandler for DebugEnumHandler {
 
                                 if let Some(method) = field_attribute.method {
                                     block_token_stream.extend(super::common::create_format_arg(
-                                        &ast.generics.params,
+                                        ast,
                                         ty,
                                         &method,
                                         quote!(#field_name_var),
@@ -230,7 +230,7 @@ impl TraitHandler for DebugEnumHandler {
 
                                 if let Some(method) = field_attribute.method {
                                     block_token_stream.extend(super::common::create_format_arg(
-                                        &ast.generics.params,
+                                        ast,
                                         ty,
                                         &method,
                                         quote!(#field_name_var),
@@ -280,7 +280,7 @@ impl TraitHandler for DebugEnumHandler {
 
                                 if let Some(method) = field_attribute.method {
                                     block_token_stream.extend(super::common::create_format_arg(
-                                        &ast.generics.params,
+                                        ast,
                                         ty,
                                         &method,
                                         quote!(#field_name_var),

--- a/src/trait_handlers/debug/debug_struct.rs
+++ b/src/trait_handlers/debug/debug_struct.rs
@@ -157,7 +157,7 @@ impl TraitHandler for DebugStructHandler {
             &ast.generics.params,
             &syn::parse2(quote!(::core::fmt::Debug)).unwrap(),
             &debug_types,
-            Some((true, false, false)),
+            &[],
         );
 
         let where_clause = ast.generics.make_where_clause();

--- a/src/trait_handlers/debug/debug_struct.rs
+++ b/src/trait_handlers/debug/debug_struct.rs
@@ -80,7 +80,7 @@ impl TraitHandler for DebugStructHandler {
 
                     if let Some(method) = field_attribute.method {
                         builder_token_stream.extend(super::common::create_format_arg(
-                            &ast.generics.params,
+                            ast,
                             ty,
                             &method,
                             quote!(&self.#field_name),
@@ -129,7 +129,7 @@ impl TraitHandler for DebugStructHandler {
 
                     if let Some(method) = field_attribute.method {
                         builder_token_stream.extend(super::common::create_format_arg(
-                            &ast.generics.params,
+                            ast,
                             ty,
                             &method,
                             quote!(&self.#field_name),

--- a/src/trait_handlers/default/default_enum.rs
+++ b/src/trait_handlers/default/default_enum.rs
@@ -166,7 +166,7 @@ impl TraitHandler for DefaultEnumHandler {
             &ast.generics.params,
             &syn::parse2(quote!(::core::default::Default)).unwrap(),
             &default_types,
-            Some((false, false, false)),
+            &[],
         );
 
         let where_clause = ast.generics.make_where_clause();

--- a/src/trait_handlers/default/default_struct.rs
+++ b/src/trait_handlers/default/default_struct.rs
@@ -111,7 +111,7 @@ impl TraitHandler for DefaultStructHandler {
             &ast.generics.params,
             &syn::parse2(quote!(::core::default::Default)).unwrap(),
             &default_types,
-            Some((false, false, false)),
+            &[],
         );
 
         let where_clause = ast.generics.make_where_clause();

--- a/src/trait_handlers/default/default_union.rs
+++ b/src/trait_handlers/default/default_union.rs
@@ -115,7 +115,7 @@ impl TraitHandler for DefaultUnionHandler {
             &ast.generics.params,
             &syn::parse2(quote!(::core::default::Default)).unwrap(),
             &default_types,
-            Some((false, false, false)),
+            &[],
         );
 
         let where_clause = ast.generics.make_where_clause();

--- a/src/trait_handlers/eq/mod.rs
+++ b/src/trait_handlers/eq/mod.rs
@@ -29,11 +29,14 @@ impl TraitHandler for EqHandler {
         }
         .build_from_eq_meta(meta)?;
 
+        let mut field_types = vec![];
+
         // if `contains_partial_eq` is true, the implementation is handled by the `PartialEq` attribute, and field attributes is also handled by the `PartialEq` attribute
         if !contains_partial_eq {
             match &ast.data {
                 Data::Struct(data) => {
                     for field in data.fields.iter() {
+                        field_types.push(&field.ty);
                         let _ =
                             FieldAttributeBuilder.build_from_attributes(&field.attrs, traits)?;
                     }
@@ -46,6 +49,7 @@ impl TraitHandler for EqHandler {
                         .build_from_attributes(&variant.attrs, traits)?;
 
                         for field in variant.fields.iter() {
+                            field_types.push(&field.ty);
                             let _ = FieldAttributeBuilder
                                 .build_from_attributes(&field.attrs, traits)?;
                         }
@@ -53,6 +57,7 @@ impl TraitHandler for EqHandler {
                 },
                 Data::Union(data) => {
                     for field in data.fields.named.iter() {
+                        field_types.push(&field.ty);
                         let _ =
                             FieldAttributeBuilder.build_from_attributes(&field.attrs, traits)?;
                     }
@@ -73,9 +78,11 @@ impl TraitHandler for EqHandler {
 
                 // The above code will throw a compile error because T have to be bound to `PartialEq`. However, it seems not to be necessary logically.
             */
-            let bound = type_attribute.bound.into_where_predicates_by_generic_parameters(
+            let bound = type_attribute.bound.into_where_predicates_by_generic_parameters_check_types(
                 &ast.generics.params,
                 &syn::parse2(quote!(::core::cmp::PartialEq)).unwrap(),
+                &field_types,
+                &[quote!{::core::cmp::PartialEq}],
             );
 
             let where_clause = ast.generics.make_where_clause();

--- a/src/trait_handlers/eq/mod.rs
+++ b/src/trait_handlers/eq/mod.rs
@@ -78,12 +78,13 @@ impl TraitHandler for EqHandler {
 
                 // The above code will throw a compile error because T have to be bound to `PartialEq`. However, it seems not to be necessary logically.
             */
-            let bound = type_attribute.bound.into_where_predicates_by_generic_parameters_check_types(
-                &ast.generics.params,
-                &syn::parse2(quote!(::core::cmp::PartialEq)).unwrap(),
-                &field_types,
-                &[quote!{::core::cmp::PartialEq}],
-            );
+            let bound =
+                type_attribute.bound.into_where_predicates_by_generic_parameters_check_types(
+                    &ast.generics.params,
+                    &syn::parse2(quote!(::core::cmp::PartialEq)).unwrap(),
+                    &field_types,
+                    &[quote! {::core::cmp::PartialEq}],
+                );
 
             let where_clause = ast.generics.make_where_clause();
 

--- a/src/trait_handlers/hash/hash_enum.rs
+++ b/src/trait_handlers/hash/hash_enum.rs
@@ -143,7 +143,7 @@ impl TraitHandler for HashEnumHandler {
             &ast.generics.params,
             &syn::parse2(quote!(::core::hash::Hash)).unwrap(),
             &hash_types,
-            Some((true, false, false)),
+            &[],
         );
 
         let where_clause = ast.generics.make_where_clause();

--- a/src/trait_handlers/hash/hash_struct.rs
+++ b/src/trait_handlers/hash/hash_struct.rs
@@ -62,7 +62,7 @@ impl TraitHandler for HashStructHandler {
             &ast.generics.params,
             &syn::parse2(quote!(::core::hash::Hash)).unwrap(),
             &hash_types,
-            Some((true, false, false)),
+            &[],
         );
 
         let where_clause = ast.generics.make_where_clause();

--- a/src/trait_handlers/into/into_enum.rs
+++ b/src/trait_handlers/into/into_enum.rs
@@ -192,7 +192,7 @@ impl TraitHandlerMultiple for IntoEnumHandler {
                     &ast.generics.params,
                     &syn::parse2(quote!(::core::convert::Into<#target_ty>)).unwrap(),
                     &into_types,
-                    None,
+                    &[],
                 );
 
                 // clone generics in order to not to affect other Into<T> implementations

--- a/src/trait_handlers/into/into_struct.rs
+++ b/src/trait_handlers/into/into_struct.rs
@@ -138,7 +138,7 @@ impl TraitHandlerMultiple for IntoStructHandler {
                     &ast.generics.params,
                     &syn::parse2(quote!(::core::convert::Into<#target_ty>)).unwrap(),
                     &into_types,
-                    None,
+                    &[],
                 );
 
                 // clone generics in order to not to affect other Into<T> implementations

--- a/src/trait_handlers/ord/mod.rs
+++ b/src/trait_handlers/ord/mod.rs
@@ -33,13 +33,17 @@ impl TraitHandler for OrdHandler {
     }
 }
 
-fn supertraits(traits: &[Trait]) -> Vec<proc_macro2::TokenStream> {
+fn supertraits(
+    #[allow(unused_variables)]
+    traits: &[Trait],
+) -> Vec<proc_macro2::TokenStream> {
     let mut supertraits = vec![];
     supertraits.push(quote! {::core::cmp::Eq});
 
     // We mustn't add the PartialOrd bound to the educed PartialOrd impl.
     // When we're educing PartialOrd we can leave it off the Ord impl too,
     // since we *know* Self is going to be PartialOrd.
+    #[cfg(feature = "PartialOrd")]
     if !traits.contains(&Trait::PartialOrd) {
         supertraits.push(quote! {::core::cmp::PartialOrd});
     };

--- a/src/trait_handlers/ord/mod.rs
+++ b/src/trait_handlers/ord/mod.rs
@@ -33,10 +33,7 @@ impl TraitHandler for OrdHandler {
     }
 }
 
-fn supertraits(
-    #[allow(unused_variables)]
-    traits: &[Trait],
-) -> Vec<proc_macro2::TokenStream> {
+fn supertraits(#[allow(unused_variables)] traits: &[Trait]) -> Vec<proc_macro2::TokenStream> {
     let mut supertraits = vec![];
     supertraits.push(quote! {::core::cmp::Eq});
 

--- a/src/trait_handlers/ord/mod.rs
+++ b/src/trait_handlers/ord/mod.rs
@@ -3,6 +3,7 @@ mod ord_enum;
 mod ord_struct;
 mod panic;
 
+use quote::quote;
 use syn::{Data, DeriveInput, Meta};
 
 use super::TraitHandler;
@@ -30,4 +31,18 @@ impl TraitHandler for OrdHandler {
             },
         }
     }
+}
+
+fn supertraits(traits: &[Trait]) -> Vec<proc_macro2::TokenStream> {
+    let mut supertraits = vec![];
+    supertraits.push(quote! {::core::cmp::Eq});
+
+    // We mustn't add the PartialOrd bound to the educed PartialOrd impl.
+    // When we're educing PartialOrd we can leave it off the Ord impl too,
+    // since we *know* Self is going to be PartialOrd.
+    if !traits.contains(&Trait::PartialOrd) {
+        supertraits.push(quote! {::core::cmp::PartialOrd});
+    };
+
+    supertraits
 }

--- a/src/trait_handlers/ord/ord_enum.rs
+++ b/src/trait_handlers/ord/ord_enum.rs
@@ -245,7 +245,7 @@ impl TraitHandler for OrdEnumHandler {
             &ast.generics.params,
             &syn::parse2(quote!(::core::cmp::Ord)).unwrap(),
             &ord_types,
-            Some((true, false, false)),
+            &crate::trait_handlers::ord::supertraits(traits),
         );
 
         let where_clause = ast.generics.make_where_clause();

--- a/src/trait_handlers/ord/ord_struct.rs
+++ b/src/trait_handlers/ord/ord_struct.rs
@@ -83,7 +83,7 @@ impl TraitHandler for OrdStructHandler {
             &ast.generics.params,
             &syn::parse2(quote!(::core::cmp::Ord)).unwrap(),
             &ord_types,
-            Some((true, false, false)),
+            &crate::trait_handlers::ord::supertraits(traits),
         );
 
         let where_clause = ast.generics.make_where_clause();

--- a/src/trait_handlers/partial_eq/partial_eq_enum.rs
+++ b/src/trait_handlers/partial_eq/partial_eq_enum.rs
@@ -182,7 +182,7 @@ impl TraitHandler for PartialEqEnumHandler {
             &ast.generics.params,
             &syn::parse2(quote!(::core::cmp::PartialEq)).unwrap(),
             &partial_eq_types,
-            Some((true, false, false)),
+            &[],
         );
 
         let where_clause = ast.generics.make_where_clause();

--- a/src/trait_handlers/partial_eq/partial_eq_struct.rs
+++ b/src/trait_handlers/partial_eq/partial_eq_struct.rs
@@ -67,7 +67,7 @@ impl TraitHandler for PartialEqStructHandler {
             &ast.generics.params,
             &syn::parse2(quote!(::core::cmp::PartialEq)).unwrap(),
             &partial_eq_types,
-            Some((true, false, false)),
+            &[],
         );
 
         let where_clause = ast.generics.make_where_clause();

--- a/src/trait_handlers/partial_ord/partial_ord_enum.rs
+++ b/src/trait_handlers/partial_ord/partial_ord_enum.rs
@@ -250,7 +250,7 @@ impl TraitHandler for PartialOrdEnumHandler {
             &ast.generics.params,
             &syn::parse2(quote!(::core::cmp::PartialOrd)).unwrap(),
             &partial_ord_types,
-            Some((true, false, false)),
+            &[quote! {::core::cmp::PartialEq}],
         );
 
         let where_clause = ast.generics.make_where_clause();

--- a/src/trait_handlers/partial_ord/partial_ord_struct.rs
+++ b/src/trait_handlers/partial_ord/partial_ord_struct.rs
@@ -85,7 +85,7 @@ impl TraitHandler for PartialOrdStructHandler {
             &ast.generics.params,
             &syn::parse2(quote!(::core::cmp::PartialOrd)).unwrap(),
             &partial_ord_types,
-            Some((true, false, false)),
+            &[quote! {::core::cmp::PartialEq}],
         );
 
         let where_clause = ast.generics.make_where_clause();

--- a/tests/copy_clone_struct.rs
+++ b/tests/copy_clone_struct.rs
@@ -2,6 +2,8 @@
 #![no_std]
 #![allow(clippy::clone_on_copy)]
 
+use core::marker::PhantomData;
+
 use educe::Educe;
 
 #[test]
@@ -108,4 +110,73 @@ fn bound_3() {
 
     assert_eq!(1, s.f1);
     assert_eq!(1, t.0);
+}
+
+#[test]
+fn bound_4() {
+    #[derive(Educe)]
+    #[educe(Copy, Clone)]
+    struct Struct<T, U> {
+        f1: Option<T>,
+        f2: PhantomData<U>,
+    }
+
+    #[derive(Educe)]
+    #[educe(Copy, Clone)]
+    struct Tuple<T, U>(Option<T>, PhantomData<U>);
+
+    let s = Struct {
+        f1: Some(1), f2: PhantomData::<core::fmt::Formatter>
+    }
+    .clone();
+    let t = Tuple(Some(1), PhantomData::<core::fmt::Formatter>).clone();
+
+    assert_eq!(Some(1), s.f1);
+    assert_eq!(Some(1), t.0);
+}
+
+#[test]
+fn bound_5() {
+    trait Suitable {}
+    struct SuitableNotClone;
+    impl Suitable for SuitableNotClone {}
+    let phantom = PhantomData::<SuitableNotClone>;
+
+    fn copy<T: Copy>(t: &T) -> T {
+        *t
+    }
+
+    #[derive(Educe)]
+    #[educe(Copy)]
+    struct Struct<T, U> {
+        f1: Option<T>,
+        f2: PhantomData<U>,
+    }
+
+    impl<T: Clone, U: Suitable> Clone for Struct<T, U> {
+        fn clone(&self) -> Self {
+            Struct {
+                f1: self.f1.clone(), f2: PhantomData
+            }
+        }
+    }
+
+    #[derive(Educe)]
+    #[educe(Copy)]
+    struct Tuple<T, U>(Option<T>, PhantomData<U>);
+
+    impl<T: Clone, U: Suitable> Clone for Tuple<T, U> {
+        fn clone(&self) -> Self {
+            Tuple(self.0.clone(), PhantomData)
+        }
+    }
+
+    let s = copy(&Struct {
+        f1: Some(1), f2: phantom
+    });
+
+    let t = copy(&Tuple(Some(1), phantom));
+
+    assert_eq!(Some(1), s.f1);
+    assert_eq!(Some(1), t.0);
 }


### PR DESCRIPTION
This is new syntax, but it's old behavour: it's the behaviour of eg `educe(Clone(bound))` in 0.4.x, as well as the behaviour of `std`.  So this helps with migreation.

I'm not committed to this syntax, but it seems a reasonable choice out of the available options which don't already mean something in 0.5.x.

**IMPORTANT: this branch is on top of the branch for #19.**  That MR should be reviewed and land first, before tackling this one.  The new feature is just the top two commits here.