### PR TITLE
recursive enum testcase

### DIFF
--- a/tests/hash_enum.rs
+++ b/tests/hash_enum.rs
@@ -405,3 +405,42 @@ fn bound_3() {
     assert_ne!(unit_hash, struct_hash);
     assert_ne!(struct_hash, tuple_hash);
 }
+
+#[test]
+fn recursive_1() {
+    #[derive(Educe)]
+    #[educe(Hash)]
+    enum Enum {
+        Unit,
+        Unit2,
+        Boxed(Box<Enum>),
+    }
+
+    let unit_hash = {
+        let mut hasher = DefaultHasher::new();
+
+        Enum::Unit.hash(&mut hasher);
+
+        hasher.finish()
+    };
+
+    let unit2_hash = {
+        let mut hasher = DefaultHasher::new();
+
+        Enum::Unit2.hash(&mut hasher);
+
+        hasher.finish()
+    };
+
+    let unit3_hash = {
+        let mut hasher = DefaultHasher::new();
+
+        Enum::Boxed(Box::new(Enum::Unit)).hash(&mut hasher);
+
+        hasher.finish()
+    };
+
+    assert_ne!(unit_hash, unit2_hash);
+    assert_ne!(unit_hash, unit3_hash);
+    assert_ne!(unit2_hash, unit3_hash);
+}


### PR DESCRIPTION
This used to work before "Merge branch 'ijackson-precise-bounds'" (2813ba003bd24812727b74318766e3c7ea5cfd25)

And fails to compile afterwards.