### PR TITLE
Use `0:` for named-fields debug of tuples and tuple variants

### DIFF
--- a/src/common/ident_index.rs
+++ b/src/common/ident_index.rs
@@ -1,6 +1,7 @@
 use quote::ToTokens;
 use syn::{Ident, Index};
 
+#[derive(Clone)]
 pub(crate) enum IdentOrIndex {
     Ident(Ident),
     Index(Index),

--- a/src/trait_handlers/debug/debug_enum.rs
+++ b/src/trait_handlers/debug/debug_enum.rs
@@ -3,6 +3,7 @@ use syn::{Data, DeriveInput, Fields, Meta, Type};
 
 use super::models::{FieldAttributeBuilder, FieldName, TypeAttributeBuilder, TypeName};
 use crate::{common::path::path_to_string, supported_traits::Trait, trait_handlers::TraitHandler};
+use crate::common::ident_index::IdentOrIndex;
 
 pub(crate) struct DebugEnumHandler;
 
@@ -219,9 +220,9 @@ impl TraitHandler for DebugEnumHandler {
 
                                 let field_name_var = format_ident!("_{}", index);
 
-                                let key = match field_attribute.name {
-                                    FieldName::Custom(name) => name,
-                                    FieldName::Default => field_name_var.clone(),
+                                let key: IdentOrIndex = match field_attribute.name {
+                                    FieldName::Custom(name) => name.into(),
+                                    FieldName::Default => index.into(),
                                 };
 
                                 pattern_token_stream.extend(quote!(#field_name_var,));

--- a/src/trait_handlers/debug/debug_enum.rs
+++ b/src/trait_handlers/debug/debug_enum.rs
@@ -2,8 +2,11 @@ use quote::{format_ident, quote, ToTokens};
 use syn::{Data, DeriveInput, Fields, Meta, Type};
 
 use super::models::{FieldAttributeBuilder, FieldName, TypeAttributeBuilder, TypeName};
-use crate::{common::path::path_to_string, supported_traits::Trait, trait_handlers::TraitHandler};
-use crate::common::ident_index::IdentOrIndex;
+use crate::{
+    common::{ident_index::IdentOrIndex, path::path_to_string},
+    supported_traits::Trait,
+    trait_handlers::TraitHandler,
+};
 
 pub(crate) struct DebugEnumHandler;
 

--- a/src/trait_handlers/debug/debug_struct.rs
+++ b/src/trait_handlers/debug/debug_struct.rs
@@ -63,15 +63,16 @@ impl TraitHandler for DebugStructHandler {
                         continue;
                     }
 
-                    let (key, field_name) = match field_attribute.name {
+                    let field_name = IdentOrIndex::from_ident_with_index(field.ident.as_ref(), index);
+                    let key = match field_attribute.name {
                         FieldName::Custom(name) => {
-                            (name, IdentOrIndex::from_ident_with_index(field.ident.as_ref(), index))
+                            name
                         },
                         FieldName::Default => {
                             if let Some(ident) = field.ident.as_ref() {
-                                (ident.clone(), IdentOrIndex::from(ident))
+                                ident.clone()
                             } else {
-                                (format_ident!("_{}", index), IdentOrIndex::from(index))
+                                format_ident!("_{}", index)
                             }
                         },
                     };

--- a/src/trait_handlers/debug/debug_struct.rs
+++ b/src/trait_handlers/debug/debug_struct.rs
@@ -1,4 +1,4 @@
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::{Data, DeriveInput, Fields, Meta, Type};
 
 use super::{
@@ -64,17 +64,9 @@ impl TraitHandler for DebugStructHandler {
                     }
 
                     let field_name = IdentOrIndex::from_ident_with_index(field.ident.as_ref(), index);
-                    let key = match field_attribute.name {
-                        FieldName::Custom(name) => {
-                            name
-                        },
-                        FieldName::Default => {
-                            if let Some(ident) = field.ident.as_ref() {
-                                ident.clone()
-                            } else {
-                                format_ident!("_{}", index)
-                            }
-                        },
+                    let key: IdentOrIndex = match field_attribute.name {
+                        FieldName::Custom(name) => name.into(),
+                        FieldName::Default => field_name.clone(),
                     };
 
                     let ty = &field.ty;

--- a/src/trait_handlers/debug/debug_struct.rs
+++ b/src/trait_handlers/debug/debug_struct.rs
@@ -63,7 +63,8 @@ impl TraitHandler for DebugStructHandler {
                         continue;
                     }
 
-                    let field_name = IdentOrIndex::from_ident_with_index(field.ident.as_ref(), index);
+                    let field_name =
+                        IdentOrIndex::from_ident_with_index(field.ident.as_ref(), index);
                     let key: IdentOrIndex = match field_attribute.name {
                         FieldName::Custom(name) => name.into(),
                         FieldName::Default => field_name.clone(),

--- a/tests/debug_enum.rs
+++ b/tests/debug_enum.rs
@@ -253,7 +253,7 @@ fn named_field_1() {
             f1: 1
         })
     );
-    assert_eq!("Tuple { _0: 1 }", format!("{:?}", Enum::Tuple(1)));
+    assert_eq!("Tuple { 0: 1 }", format!("{:?}", Enum::Tuple(1)));
 }
 
 #[test]
@@ -273,7 +273,7 @@ fn named_field_2() {
             f1: 1
         })
     );
-    assert_eq!("Tuple { _0: 1 }", format!("{:?}", Enum::Tuple(1)));
+    assert_eq!("Tuple { 0: 1 }", format!("{:?}", Enum::Tuple(1)));
 }
 
 #[test]
@@ -302,7 +302,7 @@ fn named_field_3() {
             f1: 1
         })
     );
-    assert_eq!("Tuple { _0: Hi }", format!("{:?}", Enum::Tuple(1)));
+    assert_eq!("Tuple { 0: Hi }", format!("{:?}", Enum::Tuple(1)));
 }
 
 #[test]

--- a/tests/debug_struct.rs
+++ b/tests/debug_struct.rs
@@ -245,7 +245,7 @@ fn named_field_1() {
     #[educe(Debug(named_field = true))]
     struct Tuple(u8);
 
-    assert_eq!("Tuple { _0: 1 }", format!("{:?}", Tuple(1)));
+    assert_eq!("Tuple { 0: 1 }", format!("{:?}", Tuple(1)));
 }
 
 #[test]
@@ -267,7 +267,7 @@ fn named_field_2() {
     #[educe(Debug(named_field(true)))]
     struct Tuple(u8);
 
-    assert_eq!("Tuple { _0: 1 }", format!("{:?}", Tuple(1)));
+    assert_eq!("Tuple { 0: 1 }", format!("{:?}", Tuple(1)));
 }
 
 #[test]


### PR DESCRIPTION
Change the output when the user requests debug printing of a tuple struct in named fields syntax.

Previously we output `_0: ` (for example), which isn't really right: Rust permits `0: `, and the field is actually called `0`.

This is a behavioural change, but I don't think Debug output is regarded as semver-relevant, so this shouldn't be a considered breaking change.
