### PR TITLE
enable bound on `PartialOrd`

### DIFF
--- a/src/trait_handlers/partial_ord/mod.rs
+++ b/src/trait_handlers/partial_ord/mod.rs
@@ -28,7 +28,7 @@ impl TraitHandler for PartialOrdHandler {
         // if `contains_ord` is true, the implementation is handled by the `Ord` attribute
         if contains_ord {
             let _ = TypeAttributeBuilder {
-                enable_flag: true, enable_bound: false
+                enable_flag: true, enable_bound: true
             }
             .build_from_partial_ord_meta(meta)?;
 


### PR DESCRIPTION
With `educe` 0.6.0, the syntax `PartialOrd(bound(...))` is not accepted, even though the similar syntax `PartialEq(bound(...))` is.  The README indicates this syntax should be accepted.  This PR makes a small change that seems to enable this syntax, and it works in a simple test case on my machine.