### PR TITLE
Propagate lint attributes

### DIFF
--- a/src/trait_handlers/debug/debug_enum.rs
+++ b/src/trait_handlers/debug/debug_enum.rs
@@ -348,7 +348,16 @@ impl TraitHandler for DebugEnumHandler {
 
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
+        let lint_attributes: Vec<_> = ast
+            .attrs
+            .iter()
+            .filter(|attribute| {
+                attribute.path().is_ident("allow") || attribute.path().is_ident("expect")
+            })
+            .collect();
+
         token_stream.extend(quote! {
+            #(#lint_attributes)*
             impl #impl_generics ::core::fmt::Debug for #ident #ty_generics #where_clause {
                 #[inline]
                 fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {


### PR DESCRIPTION
This addresses #34 and allows users to propagate lint attributes.

If you are willing to accept a MR in this direction, I'll be happy to improve it and apply it to other derive macros.

Other approaches would be:
1. Add a simple hard-coded 
   ```rust
   #[expect(clippy::allow_attributes, reason = "Users may force the use of 'expect'")]
   #[allow(clippy::used_underscore_binding, reason = "We use underscore to avoid clashes")]
   ```
   This shifts the maintenance burden from the users to the maintainers, i.e. every new lint that is affected needs to be added.
2. Avoid underscore bindings altogether (which seems to be rather complicated).
3. Mark the code as generated and avoid it from being linted (I don't know how this is possible).


I'm looking forward to your feedback, thanks!

---

# Example

The code

```rust 
#![deny(clippy::allow_attributes, clippy::used_underscore_binding)]

use educe::Educe;

#[derive(Educe)]
#[educe(Debug)]
#[expect(clippy::allow_attributes, reason = "Educe Shenanigans")]
#[allow(clippy::used_underscore_binding, reason = "just a test")]
pub enum Foo {
    Bar { size: usize },
}

fn main() {
    println!("{:#?}", Foo::Bar { size: 45 });
}
```

is expanded to 

```rust
#![feature(prelude_import)]
#![deny(clippy::allow_attributes, clippy::used_underscore_binding)]
#[macro_use]
extern crate std;
#[prelude_import]
use std::prelude::rust_2024::*;
use educe::Educe;
#[educe(Debug)]
#[expect(clippy::allow_attributes, reason = "Educe Shenanigans")]
#[allow(clippy::used_underscore_binding, reason = "just a test")]
pub enum Foo {
    Bar { size: usize },
}
#[expect(clippy::allow_attributes, reason = "Educe Shenanigans")]
#[allow(clippy::used_underscore_binding, reason = "just a test")]
impl ::core::fmt::Debug for Foo
where
    usize: ::core::fmt::Debug,
{
    #[inline]
    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
        match self {
            Self::Bar { size: _size } => {
                let mut builder = f.debug_struct("Bar");
                builder.field("size", _size);
                builder.finish()
            }
        }
    }
}
fn main() {
    {
        ::std::io::_print(format_args!("{0:#?}\n", Foo::Bar { size: 45 }));
    };
}
```