### PR TITLE
Use BTreeMap for deterministic Into impl order (fixes #48)

### DIFF
--- a/src/trait_handlers/into/models/type_attribute.rs
+++ b/src/trait_handlers/into/models/type_attribute.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use syn::{punctuated::Punctuated, Attribute, Meta, Token};
 
@@ -8,7 +8,7 @@ use crate::{
 };
 
 pub(crate) struct TypeAttribute {
-    pub(crate) types: HashMap<HashType, Bound>,
+    pub(crate) types: BTreeMap<HashType, Bound>,
 }
 
 #[derive(Debug)]
@@ -20,7 +20,7 @@ impl TypeAttributeBuilder {
     pub(crate) fn build_from_into_meta(&self, meta: &[Meta]) -> syn::Result<TypeAttribute> {
         debug_assert!(!meta.is_empty());
 
-        let mut types = HashMap::new();
+        let mut types = BTreeMap::new();
 
         for meta in meta {
             debug_assert!(meta.path().is_ident("Into"));
@@ -147,7 +147,7 @@ impl TypeAttributeBuilder {
         }
 
         Ok(output.unwrap_or(TypeAttribute {
-            types: HashMap::new()
+            types: BTreeMap::new()
         }))
     }
 }


### PR DESCRIPTION
Fixes #48.

The `Into` derive emits one `impl Into<…>` block per entry of `TypeAttribute.types`, which is a `std::collections::HashMap`. `HashMap` iteration order is randomized per process (getrandom seed), so the generated `impl` blocks come out in a different order on every compile, which changes the **consuming crate's metadata hash (SVH)**. Under content-addressed build systems with a shared cache this causes the same input to produce different artifacts, and mixing a fresh build with a cached dependency fails with `error[E0463]: can't find crate` (the proc-macro variant of rust-lang/rust#89904).

`HashType` already implements `Ord`, so this PR switches `TypeAttribute.types` from `HashMap` to `BTreeMap` — deterministic iteration order, no other change.

**Verified:** a struct with several `Into` targets, built three times with a clean rebuild each, produced three different `.rmeta` hashes before this change and three identical hashes after.
